### PR TITLE
Created example of support for binary key formats.

### DIFF
--- a/project/Rediscala.scala
+++ b/project/Rediscala.scala
@@ -43,7 +43,7 @@ object Dependencies {
 object RediscalaBuild extends Build {
   val baseSourceUrl = "https://github.com/etaty/rediscala/tree/"
 
-  val v = "1.3"
+  val v = "1.3-cs-branch"
 
   lazy val standardSettings = Defaults.defaultSettings ++
     Seq(

--- a/src/main/scala/redis/api/Keys.scala
+++ b/src/main/scala/redis/api/Keys.scala
@@ -20,9 +20,9 @@ case class Dump[K, R](key: K)(implicit redisKey: ByteStringSerializer[K], deseri
   val deserializer: ByteStringDeserializer[R] = deserializerR
 }
 
-case class Exists[K](key: K)(implicit redisKey: ByteStringSerializer[K]) extends RedisCommandIntegerBoolean {
+case class Exists[K](key: K, prefix: Option[String] = None)(implicit redisKey: ByteStringSerializer[K]) extends RedisCommandIntegerBoolean {
   val isMasterOnly = false
-  val encodedRequest: ByteString = encode("EXISTS", Seq(redisKey.serialize(key)))
+  val encodedRequest: ByteString = encode("EXISTS", Seq(prefix.map(ByteString(_)).getOrElse(ByteString("")) ++ redisKey.serialize(key)))
 }
 
 case class Expire[K](key: K, seconds: Long)(implicit redisKey: ByteStringSerializer[K]) extends RedisCommandIntegerBoolean {

--- a/src/main/scala/redis/api/Strings.scala
+++ b/src/main/scala/redis/api/Strings.scala
@@ -108,7 +108,7 @@ case class Psetex[K, V](key: K, milliseconds: Long, value: V)(implicit redisKey:
 }
 
 case class Set[K, V](key: K, value: V, exSeconds: Option[Long] = None, pxMilliseconds: Option[Long] = None,
-                     NX: Boolean = false, XX: Boolean = false)
+                     NX: Boolean = false, XX: Boolean = false, prefix: Option[String] = None)
                     (implicit redisKey: ByteStringSerializer[K], convert: ByteStringSerializer[V]) extends RedisCommandRedisReply[Boolean] {
   val isMasterOnly = true
   val encodedRequest: ByteString = {
@@ -116,7 +116,7 @@ case class Set[K, V](key: K, value: V, exSeconds: Option[Long] = None, pxMillise
     val options: Seq[ByteString] = exSeconds.map(t => Seq(ByteString("EX"), ByteString(t.toString)))
       .orElse(pxMilliseconds.map(t => Seq(ByteString("PX"), ByteString(t.toString))))
       .getOrElse(seq)
-    val args = redisKey.serialize(key) +: convert.serialize(value) +: options
+    val args = (prefix.map(ByteString(_)).getOrElse(ByteString("")) ++ redisKey.serialize(key)) +: convert.serialize(value) +: options
     RedisProtocolRequest.multiBulk("SET", args)
   }
 

--- a/src/main/scala/redis/commands/Keys.scala
+++ b/src/main/scala/redis/commands/Keys.scala
@@ -17,6 +17,9 @@ trait Keys extends Request {
   def exists(key: String): Future[Boolean] =
     send(Exists(key))
 
+  def existsB[K](key: K, prefix: Option[String] = None)(implicit redisKey: ByteStringSerializer[K]): Future[Boolean] =
+    send(Exists(key))
+
   def expire(key: String, seconds: Long): Future[Boolean] =
     send(Expire(key, seconds))
 

--- a/src/main/scala/redis/commands/Strings.scala
+++ b/src/main/scala/redis/commands/Strings.scala
@@ -70,6 +70,15 @@ trait Strings extends Request {
   def psetex[V: ByteStringSerializer](key: String, milliseconds: Long, value: V): Future[Boolean] =
     send(Psetex(key, milliseconds, value))
 
+  def setB[K, V: ByteStringSerializer](key: K, value: V,
+                                      exSeconds: Option[Long] = None,
+                                      pxMilliseconds: Option[Long] = None,
+                                      NX: Boolean = false,
+                                      XX: Boolean = false,
+                                      prefix: Option[String] = None)(implicit redisKey: ByteStringSerializer[K]): Future[Boolean] = {
+    send(Set(key, value, exSeconds, pxMilliseconds, NX, XX, prefix))
+  }
+
   def set[V: ByteStringSerializer](key: String, value: V,
                                    exSeconds: Option[Long] = None,
                                    pxMilliseconds: Option[Long] = None,
@@ -94,6 +103,3 @@ trait Strings extends Request {
     send(Strlen(key))
 
 }
-
-
-


### PR DESCRIPTION
There are various performance reasons to use binary key formats (and of course good debugability reasons not to). Redis certainly supports this. 

Near as I can tell, support for this is already present in the backend of rediscala. It's merely the API that doesn't expose it, but please correct me if I'm wrong if I missed something. 

This pull request exposes the binary API in the `setB` and `existsB` methods. I'd be happy to port more methods over if this seems like a useful API. 
