### PR TITLE
Implement configurable reconnect duration

### DIFF
--- a/src/main/scala/redis/actors/RedisClientActor.scala
+++ b/src/main/scala/redis/actors/RedisClientActor.scala
@@ -6,8 +6,11 @@ import redis.{Redis, Operation, Transaction}
 import akka.actor._
 import scala.collection.mutable
 import akka.actor.SupervisorStrategy.Stop
+import scala.concurrent.duration.FiniteDuration
 
-class RedisClientActor(override val address: InetSocketAddress, getConnectOperations: () => Seq[Operation[_, _]]) extends RedisWorkerIO(address) {
+class RedisClientActor(override val address: InetSocketAddress,
+                       reconnectDuration: FiniteDuration,
+                       getConnectOperations: () => Seq[Operation[_, _]]) extends RedisWorkerIO(address, reconnectDuration) {
 
 
   import context._

--- a/src/main/scala/redis/actors/RedisWorkerIO.scala
+++ b/src/main/scala/redis/actors/RedisWorkerIO.scala
@@ -10,8 +10,10 @@ import akka.io.Tcp.Register
 import akka.io.Tcp.Connect
 import akka.io.Tcp.CommandFailed
 import akka.io.Tcp.Received
+import scala.concurrent.duration.FiniteDuration
 
-abstract class RedisWorkerIO(val address: InetSocketAddress) extends Actor with ActorLogging {
+abstract class RedisWorkerIO(val address: InetSocketAddress,
+                             reconnectDuration: FiniteDuration) extends Actor with ActorLogging {
 
   private var currAddress = address
 
@@ -167,10 +169,6 @@ abstract class RedisWorkerIO(val address: InetSocketAddress) extends Actor with 
       bufferWrite.append(byteString)
     }
   }
-
-  import scala.concurrent.duration.{DurationInt, FiniteDuration}
-
-  def reconnectDuration: FiniteDuration = 2 seconds
 
   private def writeWorker(byteString: ByteString) {
     onWriteSent()

--- a/src/test/scala/redis/RedisPubSubSpec.scala
+++ b/src/test/scala/redis/RedisPubSubSpec.scala
@@ -6,6 +6,7 @@ import redis.actors.RedisSubscriberActor
 import java.net.InetSocketAddress
 import akka.actor.{Props, ActorRef}
 import akka.testkit.{TestActorRef, TestProbe}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 class RedisPubSubSpec extends RedisSpec {
 
@@ -47,7 +48,7 @@ class RedisPubSubSpec extends RedisSpec {
       val patterns = Seq("pattern.*")
 
       val subscriberActor = TestActorRef[SubscriberActor](
-        Props(classOf[SubscriberActor], new InetSocketAddress("localhost", 6379),
+        Props(classOf[SubscriberActor], new InetSocketAddress("localhost", 6379), 2 seconds,
           channels, patterns, probeMock.ref)
           .withDispatcher(Redis.dispatcher),
         "SubscriberActor"
@@ -109,10 +110,11 @@ class RedisPubSubSpec extends RedisSpec {
 }
 
 class SubscriberActor(address: InetSocketAddress,
+                      reconnectDuration: FiniteDuration,
                       channels: Seq[String],
                       patterns: Seq[String],
                       probeMock: ActorRef
-                       ) extends RedisSubscriberActor(address, channels, patterns) {
+                       ) extends RedisSubscriberActor(address, channels, patterns, reconnectDuration) {
 
   override def onMessage(m: Message) = {
     probeMock ! m

--- a/src/test/scala/redis/actors/RedisClientActorSpec.scala
+++ b/src/test/scala/redis/actors/RedisClientActorSpec.scala
@@ -8,10 +8,10 @@ import java.net.InetSocketAddress
 import akka.util.ByteString
 import scala.concurrent.{Await, Promise}
 import scala.collection.mutable
-import redis.{RedisCommand, Redis, Operation}
+import redis.{Redis, Operation}
 import redis.api.connection.Ping
 import redis.api.strings.Get
-import redis.protocol.Bulk
+import scala.concurrent.duration.DurationInt
 
 class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike with Tags with NoTimeConversions with ImplicitSender {
 
@@ -127,8 +127,10 @@ class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike
   }
 }
 
-class RedisClientActorMock(probeReplyDecoder: ActorRef, probeMock: ActorRef, getConnectOperations: () => Seq[Operation[_, _]])
-  extends RedisClientActor(new InetSocketAddress("localhost", 6379), getConnectOperations) {
+class RedisClientActorMock(probeReplyDecoder: ActorRef,
+                           probeMock: ActorRef,
+                           getConnectOperations: () => Seq[Operation[_, _]])
+  extends RedisClientActor(new InetSocketAddress("localhost", 6379), 2 seconds, getConnectOperations) {
   override def initRepliesDecoder() = probeReplyDecoder
 
   override def preStart() {

--- a/src/test/scala/redis/actors/RedisReplyDecoderSpec.scala
+++ b/src/test/scala/redis/actors/RedisReplyDecoderSpec.scala
@@ -11,6 +11,7 @@ import java.net.InetSocketAddress
 import com.typesafe.config.ConfigFactory
 import redis.{Redis, Operation}
 import redis.api.connection.Ping
+import scala.concurrent.duration.DurationInt
 
 class RedisReplyDecoderSpec
   extends TestKit(ActorSystem("testsystem", ConfigFactory.parseString( """akka.loggers = ["akka.testkit.TestEventListener"]""")))
@@ -173,7 +174,7 @@ class RedisReplyDecoderSpec
 }
 
 class RedisClientActorMock2(probeMock: ActorRef)
-  extends RedisClientActor(new InetSocketAddress("localhost", 6379), () => {Seq()}) {
+  extends RedisClientActor(new InetSocketAddress("localhost", 6379), 2 seconds, () => {Seq()}) {
   override def preStart() {
     // disable preStart of RedisWorkerIO
   }


### PR DESCRIPTION
Sometimes (e.g. in tests) there is no need to wait for 2 seconds to reconnect (e.g. 1 sec is enough).
