### PR TITLE
Dependencies upgrade (Akka, SBT, Scala, SCoverage, ...)

### DIFF
--- a/project/Rediscala.scala
+++ b/project/Rediscala.scala
@@ -5,6 +5,8 @@ import com.typesafe.sbt.SbtGit.{GitKeys => git}
 import com.typesafe.sbt.SbtSite._
 import sbt.LocalProject
 import sbt.Tests.{InProcess, Group}
+import ScoverageSbtPlugin.instrumentSettings
+import CoverallsPlugin.coverallsSettings
 
 object Resolvers {
   val typesafe = Seq(
@@ -16,7 +18,7 @@ object Resolvers {
 }
 
 object Dependencies {
-  val akkaVersion = "2.2.1"
+  val akkaVersion = "2.3.2"
 
   import sbt._
 
@@ -28,29 +30,25 @@ object Dependencies {
 
   val scalameter = "com.github.axel22" %% "scalameter" % "0.4-M2"
 
-  // @see https://github.com/mtkopone/scct/issues/54
-  val scct = "reaktor" %% "scct" % "0.2-SNAPSHOT"
-
   val rediscalaDependencies = Seq(
     akkaActor,
     akkaTestkit % "test",
     scalameter % "test",
-    specs2 % "test",
-    scct % "test"
+    specs2 % "test"
   )
 }
 
 object RediscalaBuild extends Build {
   val baseSourceUrl = "https://github.com/etaty/rediscala/tree/"
 
-  val v = "1.3"
+  val v = "1.3.1"
 
   lazy val standardSettings = Defaults.defaultSettings ++
     Seq(
       name := "rediscala",
       version := v,
       organization := "com.etaty.rediscala",
-      scalaVersion := "2.10.2",
+      scalaVersion := "2.10.4",
       resolvers ++= Resolvers.resolversList,
 
       publishTo <<= version {
@@ -77,8 +75,7 @@ object RediscalaBuild extends Build {
         )
       }
   ) ++ site.settings ++ site.includeScaladoc(v +"/api") ++ site.includeScaladoc("latest/api") ++ ghpages.settings ++
-    ScctPlugin.instrumentSettings ++
-    com.github.theon.coveralls.CoverallsPlugin.coverallsSettings
+    instrumentSettings ++ coverallsSettings
 
   lazy val BenchTest = config("bench") extend Test
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,12 +5,12 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.6.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.1")
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.1.1")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
 
-resolvers += "scct-github-repository" at "http://mtkopone.github.io/scct/maven-repo"
+resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("reaktor" % "sbt-scct" % "0.2-SNAPSHOT")
+addSbtPlugin("com.sksamuel.scoverage" %% "sbt-scoverage" % "0.95.7")
 
-addSbtPlugin("com.github.theon" %% "xsbt-coveralls-plugin" % "0.0.3")
+addSbtPlugin("com.sksamuel.scoverage" %% "sbt-coveralls" % "0.0.5")
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")


### PR DESCRIPTION
Hi Valerian :)
Here is a PR to upgrade most of Rediscala's dependencies, notably Akka.

Upgraded
- SBT from version 0.12.4 to 0.13.2
- Scala from 2.10.2 to 2.10.4
- Akka from 2.2.1 to 2.3.2
- SCCT from unmaintained version to SCoverage (v0.95.7, and its Coveralls plugin 0.0.5)
- SBT Unidoc from 0.1.1 to 0.3.1

Changed Rediscala version from 1.3 to 1.3.1

About 10 tests are failing, but situation seems to be the same in `etaty:master`
