### PR TITLE
compile against scala 2.11.2 (by default)

### DIFF
--- a/project/Rediscala.scala
+++ b/project/Rediscala.scala
@@ -5,6 +5,7 @@ import com.typesafe.sbt.SbtGit.{GitKeys => git}
 import com.typesafe.sbt.SbtSite._
 import sbt.LocalProject
 import sbt.Tests.{InProcess, Group}
+import scoverage.ScoverageSbtPlugin
 
 object Resolvers {
   val typesafe = Seq(
@@ -46,8 +47,8 @@ object RediscalaBuild extends Build {
       name := "rediscala",
       version := v,
       organization := "com.etaty.rediscala",
-      scalaVersion := "2.10.4",
-      crossScalaVersions := Seq("2.11.0", "2.10.4"),
+      scalaVersion := "2.11.2",
+      crossScalaVersions := Seq("2.11.2", "2.10.4"),
       licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
       resolvers ++= Resolvers.resolversList,
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
 
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("com.sksamuel.scoverage" %% "sbt-scoverage" % "0.95.7")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "0.99.7.1")
 
 addSbtPlugin("com.sksamuel.scoverage" %% "sbt-coveralls" % "0.0.5")
 


### PR DESCRIPTION
Compiling against 2.11 didn't work for me, because scoverage 2.11 build was missing. I received the following error:

``` sh
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: com.sksamuel.scoverage#scalac-scoverage-plugin_2.11;0.95.7: not foun
```

This pull request updates scoverage to the latest version, and resolves this issue.

Update to scoverage plugin version with 2.11 build
