### PR TITLE
update scala 2.11.2 and akka 2.3.5

### DIFF
--- a/project/Rediscala.scala
+++ b/project/Rediscala.scala
@@ -15,7 +15,7 @@ object Resolvers {
 }
 
 object Dependencies {
-  val akkaVersion = "2.3.2"
+  val akkaVersion = "2.3.5"
 
   import sbt._
 
@@ -47,7 +47,7 @@ object RediscalaBuild extends Build {
       version := v,
       organization := "com.etaty.rediscala",
       scalaVersion := "2.10.4",
-      crossScalaVersions := Seq("2.11.0", "2.10.4"),
+      crossScalaVersions := Seq("2.11.2", "2.10.4"),
       licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
       resolvers ++= Resolvers.resolversList,
 


### PR DESCRIPTION
akka 2.3.2 and scala 2.11.0 are so terrible!

http://akka.io/news/2014/05/22/akka-2.3.3-released.html

> If you were using Akka 2.3.2 for Scala 2.11.0 you need to update immediately, because serialization was broken in Scala
