### PR TITLE
redis connection status:not try to use slave down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Session.vim
 *~
 .DS_Store
 *.rdb
+temp-rewriteaof-bg-9519.aof

--- a/project/Rediscala.scala
+++ b/project/Rediscala.scala
@@ -25,11 +25,14 @@ object Dependencies {
 
   val specs2 = "org.specs2" %% "specs2" % "2.3.11"
 
+  val stm = "org.scala-stm" %% "scala-stm" % "0.7"
+
   //val scalameter = "com.github.axel22" %% "scalameter" % "0.4"
 
 
   val rediscalaDependencies = Seq(
     akkaActor,
+    stm,
     akkaTestkit % "test",
     //scalameter % "test",
     specs2 % "test"

--- a/src/main/scala/redis/Sentinel.scala
+++ b/src/main/scala/redis/Sentinel.scala
@@ -65,7 +65,7 @@ case class SentinelClient(var host: String = "localhost",
 
   val redisPubSubConnection: ActorRef = system.actorOf(
     Props(classOf[RedisSubscriberActorWithCallback],
-      new InetSocketAddress(host, port), channels, Seq(), onMessage, (pmessage: PMessage) => {}, None)
+      new InetSocketAddress(host, port), channels, Seq(), onMessage, (pmessage: PMessage) => {}, None,(status:Boolean) => {})
       .withDispatcher(Redis.dispatcher),
     name + '-' + Redis.tempName()
   )

--- a/src/main/scala/redis/actors/RedisClientActor.scala
+++ b/src/main/scala/redis/actors/RedisClientActor.scala
@@ -7,7 +7,7 @@ import akka.actor._
 import scala.collection.mutable
 import akka.actor.SupervisorStrategy.Stop
 
-class RedisClientActor(override val address: InetSocketAddress, getConnectOperations: () => Seq[Operation[_, _]]) extends RedisWorkerIO(address) {
+class RedisClientActor(override val address: InetSocketAddress, getConnectOperations: () => Seq[Operation[_, _]], onConnectStatus: Boolean => Unit  ) extends RedisWorkerIO(address,onConnectStatus) {
 
 
   import context._

--- a/src/main/scala/redis/actors/RedisSubscriberActor.scala
+++ b/src/main/scala/redis/actors/RedisSubscriberActor.scala
@@ -12,8 +12,9 @@ class RedisSubscriberActorWithCallback(
                                         patterns: Seq[String],
                                         messageCallback: Message => Unit,
                                         pmessageCallback: PMessage => Unit,
-                                        authPassword: Option[String] = None
-                                        ) extends RedisSubscriberActor(address, channels, patterns, authPassword) {
+                                        authPassword: Option[String] = None,
+                                        onConnectStatus: Boolean => Unit 
+                                        ) extends RedisSubscriberActor(address, channels, patterns, authPassword,onConnectStatus) {
   def onMessage(m: Message) = messageCallback(m)
 
   def onPMessage(pm: PMessage) = pmessageCallback(pm)
@@ -23,8 +24,9 @@ abstract class RedisSubscriberActor(
                                      address: InetSocketAddress,
                                      channels: Seq[String],
                                      patterns: Seq[String],
-                                     authPassword: Option[String] = None
-                                     ) extends RedisWorkerIO(address) with DecodeReplies {
+                                     authPassword: Option[String] = None,
+                                     onConnectStatus: Boolean => Unit 
+                                     ) extends RedisWorkerIO(address,onConnectStatus) with DecodeReplies {
   def onConnectWrite(): ByteString = {
     authPassword.map(Auth(_).encodedRequest).getOrElse(ByteString.empty)
   }

--- a/src/main/scala/redis/actors/RedisWorkerIO.scala
+++ b/src/main/scala/redis/actors/RedisWorkerIO.scala
@@ -11,7 +11,7 @@ import akka.io.Tcp.Connect
 import akka.io.Tcp.CommandFailed
 import akka.io.Tcp.Received
 
-abstract class RedisWorkerIO(val address: InetSocketAddress) extends Actor with ActorLogging {
+abstract class RedisWorkerIO(val address: InetSocketAddress, onConnectStatus: Boolean => Unit ) extends Actor with ActorLogging {
 
   private var currAddress = address
 
@@ -64,6 +64,7 @@ abstract class RedisWorkerIO(val address: InetSocketAddress) extends Actor with 
     tryInitialWrite() // TODO write something in head buffer
     become(connected)
     log.info("Connected to " + cmd.remoteAddress)
+    onConnectStatus(true)
   }
 
   def onConnectingCommandFailed(cmdFailed: CommandFailed) = {
@@ -119,6 +120,7 @@ abstract class RedisWorkerIO(val address: InetSocketAddress) extends Actor with 
   }
 
   def cleanState() {
+    onConnectStatus(false)
     onConnectionClosed()
     readyToWrite = false
     bufferWrite.clear()

--- a/src/test/scala/redis/RedisPoolSpec.scala
+++ b/src/test/scala/redis/RedisPoolSpec.scala
@@ -1,6 +1,7 @@
 package redis
 
 import scala.concurrent._
+import scala.concurrent.stm._
 import redis.api.connection.Select
 
 class RedisPoolSpec extends RedisHelper {
@@ -9,7 +10,7 @@ class RedisPoolSpec extends RedisHelper {
 
   "basic pool test" should {
     "ok" in {
-      val redisPool = RedisClientPool(Seq(RedisServer(db = Some(0)), RedisServer(db = Some(1)), RedisServer(db = Some(3))))
+      val redisPool = RedisClientPool(Seq(RedisServer(db = Some(0), active = Ref(true)), RedisServer(db = Some(1), active = Ref(true)), RedisServer(db = Some(3), active = Ref(true))))
 
       val key = "keyPoolDb0"
       redisPool.set(key, 0)
@@ -31,6 +32,29 @@ class RedisPoolSpec extends RedisHelper {
         getKey0 must beSome("0")
       }
       Await.result(r, timeOut)
+    }
+    
+    "check status" in {
+      val redisPool = RedisClientPool(Seq(RedisServer(db = Some(0), active = Ref(true)), RedisServer(db = Some(1), active = Ref(true)), RedisServer(port = 3333,db = Some(3), active = Ref(false))))
+      val key = "keyPoolDb0"
+
+      redisPool.redisConnectionPool.size mustEqual 2
+      redisPool.set(key, 0)
+      val r = for {
+        getDb1 <- redisPool.get(key)
+        getDb0 <- redisPool.get[String](key)
+        select <- Future.sequence(redisPool.broadcast(Select(0)))
+        getKey1 <- redisPool.get[String](key)
+        getKey0 <- redisPool.get[String](key)
+      } yield {
+        getDb1 must beNone
+        getDb0 must beSome("0")
+        select mustEqual Seq(true, true)
+        getKey1 must beSome("0")
+        getKey0 must beSome("0")
+      }
+      Await.result(r, timeOut)
+
     }
   }
 }

--- a/src/test/scala/redis/RedisPubSubSpec.scala
+++ b/src/test/scala/redis/RedisPubSubSpec.scala
@@ -112,7 +112,7 @@ class SubscriberActor(address: InetSocketAddress,
                       channels: Seq[String],
                       patterns: Seq[String],
                       probeMock: ActorRef
-                       ) extends RedisSubscriberActor(address, channels, patterns) {
+                       ) extends RedisSubscriberActor(address, channels, patterns, None, (b:Boolean) => () ) {
 
   override def onMessage(m: Message) = {
     probeMock ! m

--- a/src/test/scala/redis/actors/RedisClientActorSpec.scala
+++ b/src/test/scala/redis/actors/RedisClientActorSpec.scala
@@ -21,6 +21,11 @@ class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike
     Seq()
   }
 
+  val onConnectStatus: (Boolean) => Unit = (status:Boolean) => {
+
+  }
+
+
   "RedisClientActor" should {
 
     "ok" in {
@@ -38,7 +43,8 @@ class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike
         Seq(opConnectPing, opConnectGet)
       }
 
-      val redisClientActor = TestActorRef[RedisClientActorMock](Props(classOf[RedisClientActorMock], probeReplyDecoder.ref, probeMock.ref, getConnectOperations)
+    
+      val redisClientActor = TestActorRef[RedisClientActorMock](Props(classOf[RedisClientActorMock], probeReplyDecoder.ref, probeMock.ref, getConnectOperations, onConnectStatus)
         .withDispatcher(Redis.dispatcher))
 
       val promise = Promise[String]()
@@ -79,7 +85,7 @@ class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike
       val probeReplyDecoder = TestProbe()
       val probeMock = TestProbe()
 
-      val redisClientActor = TestActorRef[RedisClientActorMock](Props(classOf[RedisClientActorMock], probeReplyDecoder.ref, probeMock.ref, getConnectOperations)
+      val redisClientActor = TestActorRef[RedisClientActorMock](Props(classOf[RedisClientActorMock], probeReplyDecoder.ref, probeMock.ref, getConnectOperations, onConnectStatus)
         .withDispatcher(Redis.dispatcher))
         .underlyingActor
 
@@ -99,7 +105,7 @@ class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike
       val probeReplyDecoder = TestProbe()
       val probeMock = TestProbe()
 
-      val redisClientActorRef = TestActorRef[RedisClientActorMock](Props(classOf[RedisClientActorMock], probeReplyDecoder.ref, probeMock.ref, getConnectOperations)
+      val redisClientActorRef = TestActorRef[RedisClientActorMock](Props(classOf[RedisClientActorMock], probeReplyDecoder.ref, probeMock.ref, getConnectOperations, onConnectStatus)
         .withDispatcher(Redis.dispatcher))
       val redisClientActor = redisClientActorRef.underlyingActor
 
@@ -127,8 +133,8 @@ class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike
   }
 }
 
-class RedisClientActorMock(probeReplyDecoder: ActorRef, probeMock: ActorRef, getConnectOperations: () => Seq[Operation[_, _]])
-  extends RedisClientActor(new InetSocketAddress("localhost", 6379), getConnectOperations) {
+class RedisClientActorMock(probeReplyDecoder: ActorRef, probeMock: ActorRef, getConnectOperations: () => Seq[Operation[_, _]], onConnectStatus: Boolean => Unit )
+  extends RedisClientActor(new InetSocketAddress("localhost", 6379), getConnectOperations, onConnectStatus) {
   override def initRepliesDecoder() = probeReplyDecoder
 
   override def preStart() {

--- a/src/test/scala/redis/actors/RedisReplyDecoderSpec.scala
+++ b/src/test/scala/redis/actors/RedisReplyDecoderSpec.scala
@@ -173,7 +173,7 @@ class RedisReplyDecoderSpec
 }
 
 class RedisClientActorMock2(probeMock: ActorRef)
-  extends RedisClientActor(new InetSocketAddress("localhost", 6379), () => {Seq()}) {
+  extends RedisClientActor(new InetSocketAddress("localhost", 6379), () => {Seq()}, (status:Boolean) => {()} ) {
   override def preStart() {
     // disable preStart of RedisWorkerIO
   }

--- a/src/test/scala/redis/actors/RedisSubscriberActorSpec.scala
+++ b/src/test/scala/redis/actors/RedisSubscriberActorSpec.scala
@@ -63,7 +63,7 @@ class SubscriberActor(address: InetSocketAddress,
                       channels: Seq[String],
                       patterns: Seq[String],
                       probeMock: ActorRef
-                       ) extends RedisSubscriberActor(address, channels, patterns) {
+                       ) extends RedisSubscriberActor(address, channels, patterns, None, (status:Boolean) => {()} ) {
 
   override val tcp = probeMock
 

--- a/src/test/scala/redis/actors/RedisWorkerIOSpec.scala
+++ b/src/test/scala/redis/actors/RedisWorkerIOSpec.scala
@@ -258,7 +258,7 @@ class RedisWorkerIOSpec extends TestKit(ActorSystem()) with SpecificationLike wi
 }
 
 
-class RedisWorkerIOMock(probeTcp: ActorRef, address: InetSocketAddress, probeMock: ActorRef, _onConnectWrite: ByteString) extends RedisWorkerIO(address) {
+class RedisWorkerIOMock(probeTcp: ActorRef, address: InetSocketAddress, probeMock: ActorRef, _onConnectWrite: ByteString) extends RedisWorkerIO(address, (status:Boolean) =>{()} ) {
   override val tcp = probeTcp
 
   def writing: Receive = {


### PR DESCRIPTION
When a redis go down, it still active in redis pool.
The PR propose to disable all Redis which do not have a available connection.