### PR TITLE
Clear cached InetSocketAddress on reconnect.

### DIFF
--- a/src/main/scala/redis/Redis.scala
+++ b/src/main/scala/redis/Redis.scala
@@ -37,11 +37,9 @@ abstract class RedisClientActorLike(system: ActorRefFactory) extends ActorReques
   )
 
   def reconnect(host: String = host, port: Int = port) = {
-    if (this.host != host || this.port != port) {
-      this.host = host
-      this.port = port
-      redisConnection ! new InetSocketAddress(host, port)
-    }
+    this.host = host
+    this.port = port
+    redisConnection ! new InetSocketAddress(host, port)
   }
 
   def onConnect(redis: RedisCommands): Unit = {

--- a/src/main/scala/redis/actors/RedisWorkerIO.scala
+++ b/src/main/scala/redis/actors/RedisWorkerIO.scala
@@ -31,6 +31,8 @@ abstract class RedisWorkerIO(val address: InetSocketAddress) extends Actor with 
       tcpWorker ! Close
     }
     log.info(s"Connect to $currAddress")
+    // Create a new InetSocketAddress to clear the cached IP address.
+    currAddress = new InetSocketAddress(currAddress.getHostName, currAddress.getPort)
     tcp ! Connect(currAddress)
   }
 

--- a/src/test/scala/redis/actors/RedisWorkerIOSpec.scala
+++ b/src/test/scala/redis/actors/RedisWorkerIOSpec.scala
@@ -36,6 +36,7 @@ class RedisWorkerIOSpec extends TestKit(ActorSystem()) with SpecificationLike wi
       within(1 second, 4 seconds) {
         val connectMsg = probeTcp.expectMsgType[Connect]
         connectMsg mustEqual Connect(address)
+        connectMsg.remoteAddress must not beTheSameAs(address)
 
         val probeTcpWorker = TestProbe()
         probeTcpWorker.send(redisWorkerIO, Connected(connectMsg.remoteAddress, address))


### PR DESCRIPTION
This is necessary when the underlying IP address of a host name is changed. Recently our redis provider (Redis Labs) did some maintenance and changed the IP address of the host to which our apps were connected. Rediscala was not able to reconnect after this IP change and our apps had to be rebooted.
