### PR TITLE
Re-resolve the DNS name of the Redis server before reconnecting

### DIFF
--- a/src/main/scala/redis/Redis.scala
+++ b/src/main/scala/redis/Redis.scala
@@ -40,8 +40,11 @@ abstract class RedisClientActorLike(system: ActorRefFactory) extends ActorReques
     if (this.host != host || this.port != port) {
       this.host = host
       this.port = port
-      redisConnection ! new InetSocketAddress(host, port)
     }
+
+    // Always reset the InetSocketAddress, to re-resolve the hostname's IP.
+    // The JVM will do some caching internally anyway.
+    redisConnection ! new InetSocketAddress(host, port)
   }
 
   def onConnect(redis: RedisCommands): Unit = {

--- a/src/main/scala/redis/actors/RedisWorkerIO.scala
+++ b/src/main/scala/redis/actors/RedisWorkerIO.scala
@@ -36,6 +36,8 @@ abstract class RedisWorkerIO(val address: InetSocketAddress) extends Actor with 
 
   def reconnect() = {
     become(receive)
+    // Re-resolve the DNS name of the Redis server
+    currAddress = new InetSocketAddress(currAddress.getHostString, currAddress.getPort)
     preStart()
   }
 


### PR DESCRIPTION
This solves the case where the DNS record of the Redis server is
updated and the connection breaks. The previous code would try the same
IP address over and over, we now re-create the InetSocketAddress object
to force re-resolving.

Note that the JVM will do some DNS caching on its own (and the
operating system potentially too), this commit just fixes the issue at
library level.
