### PR TITLE
add deserializer for Array[Byte]

### DIFF
--- a/src/main/scala/redis/Converter.scala
+++ b/src/main/scala/redis/Converter.scala
@@ -176,6 +176,10 @@ trait ByteStringDeserializerDefault {
     def deserialize(bs: ByteString): String = bs.utf8String
   }
 
+  implicit object ByteArray extends ByteStringDeserializer[Array[Byte]] {
+    def deserialize(bs: ByteString): Array[Byte] = bs.toArray
+  }
+
 }
 
 trait ByteStringFormatter[T] extends ByteStringSerializer[T] with ByteStringDeserializer[T]


### PR DESCRIPTION
I think Array[Byte] is quite common data format and 
it would be nice to have it in ByteStringDeserializerDefault.
What do you think?