### PR TITLE
feature/redis-empty-slaves

### DIFF
--- a/src/main/scala/redis/RedisPool.scala
+++ b/src/main/scala/redis/RedisPool.scala
@@ -64,7 +64,7 @@ case class RedisClientMasterSlaves(master: RedisServer,
   val slavesClients = RedisClientPool(slaves)
 
   override def send[T](redisCommand: RedisCommand[_ <: RedisReply, T]): Future[T] = {
-    if (redisCommand.isMasterOnly) {
+    if (redisCommand.isMasterOnly || slaves.isEmpty) {
       masterClient.send(redisCommand)
     } else {
       slavesClients.send(redisCommand)


### PR DESCRIPTION
Certain environments may have slaves configured (i.e. production) while others may not (i.e. development).  Because `RedisClientMasterSlaves` and `RedisClient` do not share a type, it's easier to just configure variable `redis` to always be of type `RedisClientMasterSlaves` and have commands directed appropriately.  This will not currently work, however, if there happen to be no slaves configured for the environment in question.  Catching the empty condition should direct reads as well as writes to master.