### PR TITLE
#44 Sort is a master only command

### DIFF
--- a/src/main/scala/redis/api/Keys.scala
+++ b/src/main/scala/redis/api/Keys.scala
@@ -149,7 +149,7 @@ case class Sort[K: ByteStringSerializer, R](key: K,
                                             alpha: Boolean)
                                            (implicit deserializerR: ByteStringDeserializer[R])
   extends RedisCommandMultiBulkSeqByteString[R] {
-  val isMasterOnly = false
+  val isMasterOnly = true
   val encodedRequest: ByteString = encode("SORT", Sort.buildArgs(key, byPattern, limit, getPatterns, order, alpha))
   val deserializer: ByteStringDeserializer[R] = deserializerR
 }


### PR DESCRIPTION
SORT redis command is master only, so we need to configure the case class for that command accordingly