### PR TITLE
hotfix/scala-2.11-type-inference

### DIFF
--- a/project/Rediscala.scala
+++ b/project/Rediscala.scala
@@ -94,9 +94,7 @@ object RediscalaBuild extends Build {
     base = file("."),
     settings = standardSettings ++ Seq(
       libraryDependencies ++= Dependencies.rediscalaDependencies
-    )
-      ++ ScoverageSbtPlugin.instrumentSettings
-      ++ CoverallsPlugin.coverallsSettings
+    ) ++ CoverallsPlugin.coverallsSettings
   ).configs(BenchTest)
     //.settings(benchTestSettings: _* )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
 
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("com.sksamuel.scoverage" %% "sbt-scoverage" % "0.95.7")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.0.4")
 
 addSbtPlugin("com.sksamuel.scoverage" %% "sbt-coveralls" % "0.0.5")
 

--- a/src/main/scala/redis/actors/RedisWorkerIO.scala
+++ b/src/main/scala/redis/actors/RedisWorkerIO.scala
@@ -49,7 +49,9 @@ abstract class RedisWorkerIO(val address: InetSocketAddress) extends Actor with 
     readyToWrite = true
   }
 
-  def receive = connecting orElse writing
+  private def receiveWrapper(r: Receive): Receive = r
+
+  def receive: Receive = receiveWrapper { connecting orElse writing }
 
   def connecting: Receive = {
     case a: InetSocketAddress => onAddressChanged(a)
@@ -73,7 +75,7 @@ abstract class RedisWorkerIO(val address: InetSocketAddress) extends Actor with 
     scheduleReconnect()
   }
 
-  def connected: Receive = writing orElse reading
+  def connected: Receive = receiveWrapper { writing orElse reading }
 
   private def reading: Receive = {
     case WriteAck => tryWrite()

--- a/src/main/scala/redis/commands/Transactions.scala
+++ b/src/main/scala/redis/commands/Transactions.scala
@@ -110,7 +110,7 @@ case class Transaction(watcher: Set[String], operations: Queue[Operation[_, _]],
     p
   }
 
-  def dispatchExecReply(multiBulk: MultiBulk) = {
+  def dispatchExecReply(multiBulk: MultiBulk): Any = {
     multiBulk.responses.map(replies => {
       (replies, operations).zipped.map((reply, operation) => {
         reply match {


### PR DESCRIPTION
Remove compiler ERRORs concerning Receive type inference when compiling for scala 2.11.2, and upgrade scoverage plugin for 2.11

More on the Xlint compiler error stemming from combined PFs: https://issues.scala-lang.org/browse/SI-8860