### PR TITLE
feature/script-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,22 @@ You can use it with `evalshaOrEval` which run your script even if it wasn't alre
 
 Full example: [ExampleScripting](https://github.com/etaty/rediscala-demo/blob/master/src/main/scala/ExampleScripting.scala)
 
+
+`RedisScriptCache` is a helper class for loading and caching scripts included in the resource path.
+Calling `registerScripts` will load all scripts from a provided path and cache them by name, so they can be evaluated later without having to lazily load or read from source file at runtime.
+
+```scala
+  val redis = RedisClient()
+  
+  Await.result(
+    RedisScriptCache( 
+      redis = redis,
+      root = "/luaDirectory",
+      extension = ".lua"
+    ).registerScripts()
+  , 5.seconds)
+```
+
 ### Redis Sentinel
 
 [SentinelClient](http://etaty.github.io/rediscala/latest/api/index.html#redis.SentinelClient) connect to a redis sentinel server.

--- a/src/main/scala/redis/scripting/RedisScriptCache.scala
+++ b/src/main/scala/redis/scripting/RedisScriptCache.scala
@@ -1,0 +1,66 @@
+package redis.scripting
+
+import akka.actor.ActorRefFactory
+import java.io.File
+import redis.RedisClient
+import redis.api.scripting.RedisScript
+import redis.protocol.RedisReply
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContextExecutor, Future}
+
+object RedisScriptCache {
+  def fileToString(path: String): String = {
+    scala.io.Source.fromURL(getClass.getResource(path)).mkString
+  }
+
+  def apply(redis: RedisClient, root: String = "/lua", extension: String = ".lua")
+           (implicit _system: ActorRefFactory): RedisScriptCache = {
+    new RedisScriptCache(redis, root, extension)
+  }
+}
+
+class RedisScriptCache(redis: RedisClient, root: String = "/lua", extension: String = ".lua")
+                      (implicit _system: ActorRefFactory) {
+  import RedisScriptCache._
+
+  protected val scriptCache = mutable.Map.empty[String, RedisScript]
+
+
+  def nameToPath(name: String): String = {
+    if(root.takeRight(1) == "/") s"$root$name$extension"
+    else s"$root/$name$extension"
+  }
+
+  def pathToName(path: String): String = {
+    path.split("/").last.dropRight(extension.length)
+  }
+
+  def loadByPath(path: String): Future[String] = {
+    scriptCache.update(pathToName(path), RedisScript(fileToString(path)))
+    redis.scriptLoad(path)
+  }
+
+  def loadByName(name: String): Future[String] = {
+    scriptCache.update(name, RedisScript(fileToString(nameToPath(name))))
+    redis.scriptLoad(nameToPath(name))
+  }
+
+  def registerScripts()(implicit dispatcher: ExecutionContextExecutor): Future[List[String]] = {
+    val dir = new File(getClass.getResource(root).toURI.getPath)
+
+    Future.sequence(
+      dir.list
+        .filter(_.endsWith(extension))
+        .map(_.dropRight(extension.length))
+        .map(loadByName).toList
+    )
+  }
+
+
+  def run(scriptName: String, keys: Seq[String] = Seq(), args: Seq[String] = Seq())
+         (implicit dispatcher: ExecutionContextExecutor): Future[RedisReply] = {
+    val redisScript = scriptCache.getOrElseUpdate(scriptName, RedisScript(fileToString(nameToPath(scriptName))))
+    redis.evalshaOrEval(redisScript, keys, args)
+  }
+}
+

--- a/src/test/resources/lua/test1.lua
+++ b/src/test/resources/lua/test1.lua
@@ -1,0 +1,1 @@
+return "test1"

--- a/src/test/resources/lua/test2.lua
+++ b/src/test/resources/lua/test2.lua
@@ -1,0 +1,1 @@
+return "test2"

--- a/src/test/scala/redis/scripting/RedisScriptCacheSpec.scala
+++ b/src/test/scala/redis/scripting/RedisScriptCacheSpec.scala
@@ -1,0 +1,57 @@
+package redis.scripting
+
+
+import redis._
+import redis.api.scripting.RedisScript
+import scala.collection.mutable
+
+
+class RedisScriptCacheSpec extends RedisSpec {
+  sequential
+
+  /*
+  Mock class for reaching into the protected cache map
+   */
+  class TestRedisScriptCache(mockCache: mutable.Map[String, RedisScript]) extends RedisScriptCache(redis) {
+    override protected val scriptCache = mockCache
+  }
+
+  "RedisScriptCache" should {
+    "translate a script name to its appropriate path" in {
+      val mockCache = mutable.Map.empty[String, RedisScript]
+      val scriptCache = new TestRedisScriptCache(mockCache)
+      val scriptName = "test1"
+      val expectedScriptPath = s"/lua/$scriptName.lua"
+
+      scriptCache.nameToPath(scriptName) mustEqual expectedScriptPath
+    }
+
+    "load a lua script and cache its name" in {
+      val mockCache = mutable.Map.empty[String, RedisScript]
+      val scriptCache = new TestRedisScriptCache(mockCache)
+
+      val script1Name = "test1"
+      val script2Name = "test2"
+      val testScript2Path = s"/lua/$script2Name.lua"
+
+      scriptCache.loadByName(script1Name)
+      scriptCache.loadByPath(testScript2Path)
+
+      mockCache(script1Name) must beAnInstanceOf[RedisScript]
+      mockCache(script2Name) must beAnInstanceOf[RedisScript]
+    }
+
+    "register all scripts in a directory" in {
+      val mockCache = mutable.Map.empty[String, RedisScript]
+      val scriptCache = new TestRedisScriptCache(mockCache)
+
+      scriptCache.registerScripts()
+      val script1Name = "test1"
+      val script2Name = "test2"
+
+      mockCache(script1Name) must beAnInstanceOf[RedisScript]
+      mockCache(script2Name) must beAnInstanceOf[RedisScript]
+    }
+  }
+}
+


### PR DESCRIPTION
Provides a script caching class to load scripts included as files in the `resources` path.

Currently scripts are evaluated lazily, and loaded if they haven't already been.  This is a performance problem for larger scripts and for files, since they must be read and passed into `RedisScript` every time they are called.  It's a much easier and more common pattern to load Redis scripts in an initializer so they are available on-demand without having to first read and load them into Redis at runtime.

`RedisScriptCache` holds a simple `mutable.Map` to store loaded scripts with their names as keys.  It can read and register all scripts in a provided directory and return a Future response when they have all been loaded for initialization purposes.  To then run a script which has been cached, only the name of the script is needed.