### PR TITLE
Add scan commands

### DIFF
--- a/src/main/scala/redis/RedisCommand.scala
+++ b/src/main/scala/redis/RedisCommand.scala
@@ -79,14 +79,16 @@ trait RedisCommandMultiBulkSeqByteStringDouble[R] extends RedisCommandMultiBulk[
   def decodeReply(mb: MultiBulk) = MultiBulkConverter.toSeqTuple2ByteStringDouble(mb)(deserializer)
 }
 
-trait RedisCommandMultiBulkCursor[R] extends RedisCommandMultiBulk[(Int, R)] {
+case class Cursor[T](index: Int, data: T)
+
+trait RedisCommandMultiBulkCursor[R] extends RedisCommandMultiBulk[Cursor[R]] {
   def decodeReply(mb: MultiBulk) = {
     mb.responses.map { responses =>
       val cursor = ParseNumber.parseInt(responses.head.toByteString)
       val remainder = responses(1).asInstanceOf[MultiBulk]
 
-      (cursor, remainder.responses.map(decodeResponses).getOrElse(empty))
-    }.getOrElse((0, empty))
+      Cursor(cursor, remainder.responses.map(decodeResponses).getOrElse(empty))
+    }.getOrElse(Cursor(0, empty))
   }
 
   def decodeResponses(responses: Seq[RedisReply]): R

--- a/src/main/scala/redis/api/SortedSets.scala
+++ b/src/main/scala/redis/api/SortedSets.scala
@@ -3,6 +3,7 @@ package redis.api.sortedsets
 import redis._
 import akka.util.ByteString
 import redis.api.{SUM, Aggregate, Limit}
+import redis.protocol.RedisReply
 
 case class Zadd[K, V](key: K, scoreMembers: Seq[(Double, V)])(implicit keySeria: ByteStringSerializer[K], convert: ByteStringSerializer[V])
   extends RedisCommandIntegerLong {
@@ -205,3 +206,16 @@ case class Zrevrangebylex[K, R](key: K, max: String, min: String, limit: Option[
   val deserializer: ByteStringDeserializer[R] = deserializerR
 }
 
+case class Zscan[K, C, R](key: K, cursor: C, count: Option[Int], matchGlob: Option[String])(implicit redisKey: ByteStringSerializer[K], redisCursor: ByteStringSerializer[C], deserializerR: ByteStringDeserializer[R]) extends RedisCommandMultiBulkCursor[Map[Double, R]] {
+  val isMasterOnly: Boolean = false
+  val encodedRequest: ByteString = encode("ZSCAN", withOptionalParams(Seq(redisKey.serialize(key), redisCursor.serialize(cursor))))
+
+  val empty: Map[Double, R] = Map.empty
+
+  def decodeResponses(responses: Seq[RedisReply]) =
+   responses.grouped(2).map { xs =>
+     val data = xs.head
+     val score = xs(1).toByteString.utf8String.toDouble
+     score -> deserializerR.deserialize(data.toByteString)
+   }.toMap
+}

--- a/src/main/scala/redis/api/SortedSets.scala
+++ b/src/main/scala/redis/api/SortedSets.scala
@@ -206,16 +206,16 @@ case class Zrevrangebylex[K, R](key: K, max: String, min: String, limit: Option[
   val deserializer: ByteStringDeserializer[R] = deserializerR
 }
 
-case class Zscan[K, C, R](key: K, cursor: C, count: Option[Int], matchGlob: Option[String])(implicit redisKey: ByteStringSerializer[K], redisCursor: ByteStringSerializer[C], deserializerR: ByteStringDeserializer[R]) extends RedisCommandMultiBulkCursor[Map[Double, R]] {
+case class Zscan[K, C, R](key: K, cursor: C, count: Option[Int], matchGlob: Option[String])(implicit redisKey: ByteStringSerializer[K], redisCursor: ByteStringSerializer[C], deserializerR: ByteStringDeserializer[R]) extends RedisCommandMultiBulkCursor[Seq[(Double, R)]] {
   val isMasterOnly: Boolean = false
   val encodedRequest: ByteString = encode("ZSCAN", withOptionalParams(Seq(redisKey.serialize(key), redisCursor.serialize(cursor))))
 
-  val empty: Map[Double, R] = Map.empty
+  val empty: Seq[(Double, R)] = Seq.empty
 
   def decodeResponses(responses: Seq[RedisReply]) =
    responses.grouped(2).map { xs =>
      val data = xs.head
      val score = xs(1).toByteString.utf8String.toDouble
      score -> deserializerR.deserialize(data.toByteString)
-   }.toMap
+   }.toSeq
 }

--- a/src/main/scala/redis/commands/Hashes.scala
+++ b/src/main/scala/redis/commands/Hashes.scala
@@ -1,7 +1,7 @@
 package redis.commands
 
 import redis.protocol.MultiBulk
-import redis.{ByteStringDeserializer, ByteStringSerializer, Request}
+import redis.{Cursor, ByteStringDeserializer, ByteStringSerializer, Request}
 import scala.concurrent.Future
 import redis.api.hashes._
 
@@ -46,7 +46,7 @@ trait Hashes extends Request {
   def hvals[R: ByteStringDeserializer](key: String): Future[Seq[R]] =
     send(Hvals(key))
 
-  def hscan[R: ByteStringDeserializer](key: String, cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[(Int, Map[String, R])] =
+  def hscan[R: ByteStringDeserializer](key: String, cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[Cursor[Map[String, R]]] =
     send(HScan(key, cursor, count, matchGlob))
 
 }

--- a/src/main/scala/redis/commands/Hashes.scala
+++ b/src/main/scala/redis/commands/Hashes.scala
@@ -1,5 +1,6 @@
 package redis.commands
 
+import redis.protocol.MultiBulk
 import redis.{ByteStringDeserializer, ByteStringSerializer, Request}
 import scala.concurrent.Future
 import redis.api.hashes._
@@ -44,5 +45,8 @@ trait Hashes extends Request {
 
   def hvals[R: ByteStringDeserializer](key: String): Future[Seq[R]] =
     send(Hvals(key))
+
+  def hscan[R: ByteStringDeserializer](key: String, cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[(Int, Map[String, R])] =
+    send(HScan(key, cursor, count, matchGlob))
 
 }

--- a/src/main/scala/redis/commands/Keys.scala
+++ b/src/main/scala/redis/commands/Keys.scala
@@ -91,7 +91,7 @@ trait Keys extends Request {
   def `type`(key: String): Future[String] =
     send(Type(key))
 
-  def scan(cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[(Int, Seq[String])] =
+  def scan(cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[Cursor[Seq[String]]] =
     send(Scan(cursor, count, matchGlob))
 
 }

--- a/src/main/scala/redis/commands/Keys.scala
+++ b/src/main/scala/redis/commands/Keys.scala
@@ -91,4 +91,7 @@ trait Keys extends Request {
   def `type`(key: String): Future[String] =
     send(Type(key))
 
+  def scan(cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[(Int, Seq[String])] =
+    send(Scan(cursor, count, matchGlob))
+
 }

--- a/src/main/scala/redis/commands/Sets.scala
+++ b/src/main/scala/redis/commands/Sets.scala
@@ -1,6 +1,6 @@
 package redis.commands
 
-import redis.{ByteStringDeserializer, ByteStringSerializer, Request}
+import redis.{Cursor, ByteStringDeserializer, ByteStringSerializer, Request}
 import scala.concurrent.Future
 import redis.api.sets._
 
@@ -51,6 +51,6 @@ trait Sets extends Request {
   def sunionstore(destination: String, key: String, keys: String*): Future[Long] =
     send(Sunionstore(destination, key, keys))
 
-  def sscan[R: ByteStringDeserializer](key: String, cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[(Int, Seq[R])] =
+  def sscan[R: ByteStringDeserializer](key: String, cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[Cursor[Seq[R]]] =
     send(Sscan(key, cursor, count, matchGlob))
 }

--- a/src/main/scala/redis/commands/Sets.scala
+++ b/src/main/scala/redis/commands/Sets.scala
@@ -51,4 +51,6 @@ trait Sets extends Request {
   def sunionstore(destination: String, key: String, keys: String*): Future[Long] =
     send(Sunionstore(destination, key, keys))
 
+  def sscan[R: ByteStringDeserializer](key: String, cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[(Int, Seq[R])] =
+    send(Sscan(key, cursor, count, matchGlob))
 }

--- a/src/main/scala/redis/commands/SortedSets.scala
+++ b/src/main/scala/redis/commands/SortedSets.scala
@@ -84,5 +84,9 @@ trait SortedSets extends Request {
 
   def zrevrangebylex[R: ByteStringDeserializer](key: String, max: Option[String], min: Option[String], limit: Option[(Long, Long)] = None): Future[Seq[R]] =
     send(Zrevrangebylex(key, max.getOrElse("+"), max.getOrElse("-"), limit))
+
+  def zscan[R: ByteStringDeserializer](key: String, cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[(Int, Map[Double, R])] =
+    send(Zscan(key, cursor, count, matchGlob))
+
 }
 

--- a/src/main/scala/redis/commands/SortedSets.scala
+++ b/src/main/scala/redis/commands/SortedSets.scala
@@ -1,6 +1,6 @@
 package redis.commands
 
-import redis.{ByteStringDeserializer, ByteStringSerializer, Request}
+import redis.{Cursor, ByteStringDeserializer, ByteStringSerializer, Request}
 import scala.concurrent.Future
 import redis.api._
 import redis.api.sortedsets._
@@ -85,7 +85,7 @@ trait SortedSets extends Request {
   def zrevrangebylex[R: ByteStringDeserializer](key: String, max: Option[String], min: Option[String], limit: Option[(Long, Long)] = None): Future[Seq[R]] =
     send(Zrevrangebylex(key, max.getOrElse("+"), max.getOrElse("-"), limit))
 
-  def zscan[R: ByteStringDeserializer](key: String, cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[(Int, Seq[(Double, R)])] =
+  def zscan[R: ByteStringDeserializer](key: String, cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[Cursor[Seq[(Double, R)]]] =
     send(Zscan(key, cursor, count, matchGlob))
 
 }

--- a/src/main/scala/redis/commands/SortedSets.scala
+++ b/src/main/scala/redis/commands/SortedSets.scala
@@ -85,7 +85,7 @@ trait SortedSets extends Request {
   def zrevrangebylex[R: ByteStringDeserializer](key: String, max: Option[String], min: Option[String], limit: Option[(Long, Long)] = None): Future[Seq[R]] =
     send(Zrevrangebylex(key, max.getOrElse("+"), max.getOrElse("-"), limit))
 
-  def zscan[R: ByteStringDeserializer](key: String, cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[(Int, Map[Double, R])] =
+  def zscan[R: ByteStringDeserializer](key: String, cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[(Int, Seq[(Double, R)])] =
     send(Zscan(key, cursor, count, matchGlob))
 
 }

--- a/src/test/scala/redis/commands/HashesSpec.scala
+++ b/src/test/scala/redis/commands/HashesSpec.scala
@@ -147,6 +147,19 @@ class HashesSpec extends RedisSpec {
       Await.result(r, timeOut)
     }
 
+    "HSCAN" in {
+      val initialData = (1 to 20).grouped(2).map(x => x.head.toString -> x.tail.head.toString).toMap
+      val r = for {
+        _ <- redis.del("hscan")
+        _ <- redis.hmset("hscan", initialData)
+        (cursor, result) <- redis.hscan[String]("hscan", count = Some(300))
+      } yield {
+        result.values.toList.map(_.toInt).sorted mustEqual (2 to 20 by 2)
+        cursor mustEqual 0
+      }
+      Await.result(r, timeOut)
+    }
+
     "HVALS" in {
       val r = for {
         _ <- redis.hdel("hvalsKey", "field")

--- a/src/test/scala/redis/commands/HashesSpec.scala
+++ b/src/test/scala/redis/commands/HashesSpec.scala
@@ -152,10 +152,10 @@ class HashesSpec extends RedisSpec {
       val r = for {
         _ <- redis.del("hscan")
         _ <- redis.hmset("hscan", initialData)
-        (cursor, result) <- redis.hscan[String]("hscan", count = Some(300))
+        scanResult <- redis.hscan[String]("hscan", count = Some(300))
       } yield {
-        result.values.toList.map(_.toInt).sorted mustEqual (2 to 20 by 2)
-        cursor mustEqual 0
+        scanResult.data.values.toList.map(_.toInt).sorted mustEqual (2 to 20 by 2)
+        scanResult.index mustEqual 0
       }
       Await.result(r, timeOut)
     }

--- a/src/test/scala/redis/commands/KeysSpec.scala
+++ b/src/test/scala/redis/commands/KeysSpec.scala
@@ -281,6 +281,37 @@ class KeysSpec extends RedisSpec {
       Await.result(r, timeOut)
     }
 
+    // Difficult to test due to how non-deterministic SCAN is. This might fail if the user has ~2M keys in their DB.
+    "SCAN" in {
+      val populateKeys = Future.sequence(Seq(
+        redis.set("scanKey1", "value1"),
+        redis.set("scanKey2", "value2"),
+        redis.set("scanKey3", "value3"),
+        redis.set("scanKey4", "value4"),
+        redis.set("scanKey5", "value5"),
+        redis.set("scanKey6", "value6"),
+        redis.set("scanKey7", "value7")
+      ))
+      val starter: Future[(Option[Int], Set[String])] = Future.successful((None, Set[String]()))
+      val fetched = (0 to 20).foldRight(starter) { case (_, f) =>
+        f.flatMap { case (cursor: Option[Int], results: Set[String]) =>
+          if (cursor.nonEmpty && cursor.get == 0) {
+            Future.successful((cursor, results))
+          } else {
+            redis.scan(cursor = cursor.getOrElse(0), count = Some(10000), matchGlob = Some("scanKey*")).map { case (c, v) => (Option(c), results ++ v) }
+          }
+        }
+      }
+
+      val tested = populateKeys.flatMap(_ => fetched).map { case (cursor: Option[Int], keys: Set[String]) =>
+        cursor.nonEmpty mustEqual true
+        cursor.get mustEqual 0
+        keys.toList.sorted mustEqual List("scanKey1", "scanKey2", "scanKey3", "scanKey4", "scanKey5", "scanKey6", "scanKey7")
+      }
+
+      Await.result(tested, timeOut)
+    }
+
     // @see https://gist.github.com/jacqui/983051
     "SORT" in {
       val init = Future.sequence(Seq(

--- a/src/test/scala/redis/commands/KeysSpec.scala
+++ b/src/test/scala/redis/commands/KeysSpec.scala
@@ -298,7 +298,7 @@ class KeysSpec extends RedisSpec {
           if (cursor.nonEmpty && cursor.get == 0) {
             Future.successful((cursor, results))
           } else {
-            redis.scan(cursor = cursor.getOrElse(0), count = Some(10000), matchGlob = Some("scanKey*")).map { case (c, v) => (Option(c), results ++ v) }
+            redis.scan(cursor = cursor.getOrElse(0), count = Some(10000), matchGlob = Some("scanKey*")).map(scanResult => (Option(scanResult.index), results ++ scanResult.data))
           }
         }
       }

--- a/src/test/scala/redis/commands/SetsSpec.scala
+++ b/src/test/scala/redis/commands/SetsSpec.scala
@@ -182,10 +182,10 @@ class SetsSpec extends RedisSpec {
     "SSCAN" in {
       val r = for {
         _ <- redis.sadd("sscan", (1 to 20).map(_.toString):_*)
-        (cursor, results) <- redis.sscan[String]("sscan", count = Some(100))
+        scanResult <- redis.sscan[String]("sscan", count = Some(100))
       } yield {
-        cursor mustEqual 0
-        results.toList.map(_.toInt).sorted mustEqual (1 to 20)
+        scanResult.index mustEqual 0
+        scanResult.data.map(_.toInt).sorted mustEqual (1 to 20)
       }
 
       Await.result(r, timeOut)

--- a/src/test/scala/redis/commands/SetsSpec.scala
+++ b/src/test/scala/redis/commands/SetsSpec.scala
@@ -179,6 +179,18 @@ class SetsSpec extends RedisSpec {
       Await.result(r, timeOut)
     }
 
+    "SSCAN" in {
+      val r = for {
+        _ <- redis.sadd("sscan", (1 to 20).map(_.toString):_*)
+        (cursor, results) <- redis.sscan[String]("sscan", count = Some(100))
+      } yield {
+        cursor mustEqual 0
+        results.toList.map(_.toInt).sorted mustEqual (1 to 20)
+      }
+
+      Await.result(r, timeOut)
+    }
+
     "SUNION" in {
       val r = for {
         _ <- redis.del("sunionKey1")

--- a/src/test/scala/redis/commands/SortedSetsSpec.scala
+++ b/src/test/scala/redis/commands/SortedSetsSpec.scala
@@ -255,7 +255,7 @@ class SortedSetsSpec extends RedisSpec {
         (cursor, result) <- redis.zscan[String]("zscan", count = Some(100))
       } yield {
         cursor mustEqual 0
-        result mustEqual (1 to 20).map(x => x.toDouble -> x.toString).toMap
+        result mustEqual (1 to 20).map(x => x.toDouble -> x.toString)
       }
 
       Await.result(r, timeOut)

--- a/src/test/scala/redis/commands/SortedSetsSpec.scala
+++ b/src/test/scala/redis/commands/SortedSetsSpec.scala
@@ -248,6 +248,19 @@ class SortedSetsSpec extends RedisSpec {
       Await.result(r, timeOut)
     }
 
+    "ZSCAN" in {
+      val r = for {
+        _ <- redis.del("zscan")
+        _ <- redis.zadd("zscan", (1 to 20).map(x => x.toDouble -> x.toString):_*)
+        (cursor, result) <- redis.zscan[String]("zscan", count = Some(100))
+      } yield {
+        cursor mustEqual 0
+        result mustEqual (1 to 20).map(x => x.toDouble -> x.toString).toMap
+      }
+
+      Await.result(r, timeOut)
+    }
+
     "ZSCORE" in {
       val r = for {
         _ <- redis.del("zscoreKey")

--- a/src/test/scala/redis/commands/SortedSetsSpec.scala
+++ b/src/test/scala/redis/commands/SortedSetsSpec.scala
@@ -252,10 +252,10 @@ class SortedSetsSpec extends RedisSpec {
       val r = for {
         _ <- redis.del("zscan")
         _ <- redis.zadd("zscan", (1 to 20).map(x => x.toDouble -> x.toString):_*)
-        (cursor, result) <- redis.zscan[String]("zscan", count = Some(100))
+        scanResult <- redis.zscan[String]("zscan", count = Some(100))
       } yield {
-        cursor mustEqual 0
-        result mustEqual (1 to 20).map(x => x.toDouble -> x.toString)
+        scanResult.index mustEqual 0
+        scanResult.data mustEqual (1 to 20).map(x => x.toDouble -> x.toString)
       }
 
       Await.result(r, timeOut)


### PR DESCRIPTION
There's been an open issue in the issue tracker for a while about adding support for new commands from Redis 2.8: https://github.com/etaty/rediscala/issues/21

This adds support for SCAN, ZSCAN, SSCAN, and HSCAN. They're all fairly low level, as they return the cursor and leave the rest up to the caller. It would be convenient to have higher-level methods for iterating over the entire result, but I figured this was a decent starting point.

My apologies about the tests. The scan commands are all quite non-deterministic, which makes them challenging to test. I'm happy to take suggestions about how to improve these.