### PR TITLE
RedisWorkerIO: NPE onAddressChanged

### DIFF
--- a/src/main/scala/redis/actors/RedisWorkerIO.scala
+++ b/src/main/scala/redis/actors/RedisWorkerIO.scala
@@ -96,7 +96,9 @@ abstract class RedisWorkerIO(val address: InetSocketAddress, onConnectStatus: Bo
 
   def onAddressChanged(addr: InetSocketAddress) {
     log.info(s"Address change [old=$address, new=$addr]")
-    tcpWorker ! ConfirmedClose // close the sending direction of the connection (TCP FIN)
+    if (tcpWorker != null ) {
+      tcpWorker ! ConfirmedClose // close the sending direction of the connection (TCP FIN)
+    }
     currAddress = addr
     scheduleReconnect()
   }


### PR DESCRIPTION
if  onAddressChanged is called before onConnected,  onAddressChanged throw a NPE

[ERROR] [09/28/2015 08:02:50.751] [default-akka.actor.default-dispatcher-18] [akka://default/user/RedisClient-$h] null
java.lang.NullPointerException
	at redis.actors.RedisWorkerIO.onAddressChanged(RedisWorkerIO.scala:98)
	at redis.actors.RedisWorkerIO$$anonfun$connecting$1.applyOrElse(RedisWorkerIO.scala:55)
	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:170)
	at akka.actor.Actor$class.aroundReceive(Actor.scala:467)
	at redis.actors.RedisWorkerIO.aroundReceive(RedisWorkerIO.scala:14)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:516)
	at akka.actor.ActorCell.invoke(ActorCell.scala:487)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:238)
	at akka.dispatch.Mailbox.run(Mailbox.scala:220)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:397)
	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)