### PR TITLE
make Redis.dispatcher configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,14 @@ Redis commands are dispatched to redis connection in a round robin way.
 [RedisClientMasterSlaves](http://etaty.github.io/rediscala/latest/api/index.html#redis.RedisClientMasterSlaves) connect to a master and a pool of slaves.
 The `write` commands are sent to the master, while the read commands are sent to the slaves in the [RedisClientPool](http://etaty.github.io/rediscala/latest/api/index.html#redis.RedisClientPool)
 
+### Config Which Dispatcher to Use
+
+By default, the actors in this project will use the dispatcher `rediscala.rediscala-client-worker-dispatcher`. If you want to use another dispatcher, just config the implicit value of `redisDispatcher`:
+
+```scala
+implicit val redisDispatcher = RedisDispatcher("akka.actor.default-dispatcher")
+```
+
 ### ByteStringSerializer ByteStringDeserializer ByteStringFormatter
 
 [ByteStringSerializer](http://etaty.github.io/rediscala/latest/api/index.html#redis.ByteStringSerializer)

--- a/benchmark/src/main/scala/redis/RedisState.scala
+++ b/benchmark/src/main/scala/redis/RedisState.scala
@@ -8,7 +8,7 @@ case class RedisState(initF: () => Unit = () => ()) {
   val akkaSystem = akka.actor.ActorSystem()
   val redis = RedisClient()(akkaSystem)
 
-  implicit val exec = akkaSystem.dispatcher
+  implicit val exec = akkaSystem.dispatchers.lookup(Redis.dispatcher.name)
 
   import scala.concurrent.duration._
 

--- a/benchmark/src/main/scala/redis/commands/Get.scala
+++ b/benchmark/src/main/scala/redis/commands/Get.scala
@@ -3,7 +3,7 @@ package redis.commands
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-import redis.RedisStateHelper
+import redis.{Redis, RedisStateHelper}
 
 import scala.concurrent.{Await, Future}
 
@@ -18,7 +18,7 @@ class Get extends RedisStateHelper {
 
   override def initRedisState(): Unit = {
     import scala.concurrent.duration._
-    implicit val exec = rs.akkaSystem.dispatcher
+    implicit val exec = rs.akkaSystem.dispatchers.lookup(Redis.dispatcher.name)
 
     Await.result(rs.redis.set(getKey, "value"), 20 seconds)
   }
@@ -27,7 +27,7 @@ class Get extends RedisStateHelper {
   @BenchmarkMode(Array(Mode.SingleShotTime))
   def measurePing(): Unit = {
     import scala.concurrent.duration._
-    implicit def exec = rs.akkaSystem.dispatcher
+    implicit def exec = rs.akkaSystem.dispatchers.lookup(Redis.dispatcher.name)
 
     val r = for (i <- (0 to iteration).toVector) yield {
       rs.redis.get(getKey)

--- a/benchmark/src/main/scala/redis/commands/Hgetall.scala
+++ b/benchmark/src/main/scala/redis/commands/Hgetall.scala
@@ -3,7 +3,7 @@ package redis.commands
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-import redis.RedisStateHelper
+import redis.{Redis, RedisStateHelper}
 
 import scala.concurrent.{Future, Await}
 
@@ -31,7 +31,7 @@ class Hgetall extends RedisStateHelper {
 
   override def initRedisState(): Unit = {
     import scala.concurrent.duration._
-    implicit val exec = rs.akkaSystem.dispatcher
+    implicit val exec = rs.akkaSystem.dispatchers.lookup(Redis.dispatcher.name)
 
     Await.result(rs.redis.flushall(), 20 seconds)
     val r = for (i <- 0 to hashSize) yield {
@@ -45,7 +45,7 @@ class Hgetall extends RedisStateHelper {
   @BenchmarkMode(Array(Mode.SingleShotTime))
   def measureHgetall(): Seq[Map[String, String]] = {
     import scala.concurrent.duration._
-    implicit def exec = rs.akkaSystem.dispatcher
+    implicit def exec = rs.akkaSystem.dispatchers.lookup(Redis.dispatcher.name)
 
     val r = for (i <- 0 to 100) yield {
       rs.redis.hgetall[String](hsetKey)

--- a/benchmark/src/main/scala/redis/commands/Ping.scala
+++ b/benchmark/src/main/scala/redis/commands/Ping.scala
@@ -3,7 +3,7 @@ package redis.commands
 import java.util.concurrent.TimeUnit
 
 import org.openjdk.jmh.annotations._
-import redis.RedisStateHelper
+import redis.{Redis, RedisStateHelper}
 
 import scala.concurrent.{Future, Await}
 
@@ -18,7 +18,7 @@ class Ping extends RedisStateHelper {
   @BenchmarkMode(Array(Mode.SingleShotTime))
   def measurePing(): Unit = {
     import scala.concurrent.duration._
-    implicit def exec = rs.akkaSystem.dispatcher
+    implicit def exec = rs.akkaSystem.dispatchers.lookup(Redis.dispatcher.name)
 
     val r = for (i <- (0 to iteration).toVector) yield {
       rs.redis.ping()

--- a/src/main/scala/redis/actors/RedisClientActor.scala
+++ b/src/main/scala/redis/actors/RedisClientActor.scala
@@ -2,7 +2,7 @@ package redis.actors
 
 import akka.util.{ByteString, ByteStringBuilder}
 import java.net.InetSocketAddress
-import redis.{Redis, Operation, Transaction}
+import redis.{RedisDispatcher, Redis, Operation, Transaction}
 import akka.actor._
 import scala.collection.mutable
 import akka.actor.SupervisorStrategy.Stop
@@ -17,7 +17,8 @@ class RedisClientActor(override val address: InetSocketAddress, getConnectOperat
   // connection closed on the sending direction
   var oldRepliesDecoder: Option[ActorRef] = None
 
-  def initRepliesDecoder() = context.actorOf(Props(classOf[RedisReplyDecoder]).withDispatcher(Redis.dispatcher))
+  def initRepliesDecoder(implicit redisDispatcher: RedisDispatcher = Redis.dispatcher) =
+    context.actorOf(Props(classOf[RedisReplyDecoder]).withDispatcher(redisDispatcher.name))
 
   var queuePromises = mutable.Queue[Operation[_, _]]()
 

--- a/src/test/scala/redis/RedisPubSubSpec.scala
+++ b/src/test/scala/redis/RedisPubSubSpec.scala
@@ -50,7 +50,7 @@ class RedisPubSubSpec extends RedisSpec {
       val subscriberActor = TestActorRef[SubscriberActor](
         Props(classOf[SubscriberActor], new InetSocketAddress("localhost", 6379),
           channels, patterns, probeMock.ref)
-          .withDispatcher(Redis.dispatcher),
+          .withDispatcher(Redis.dispatcher.name),
         "SubscriberActor"
       )
       import scala.concurrent.duration._

--- a/src/test/scala/redis/RedisSpec.scala
+++ b/src/test/scala/redis/RedisSpec.scala
@@ -15,7 +15,7 @@ abstract class RedisHelper extends TestKit(ActorSystem()) with SpecificationLike
 
   import scala.concurrent.duration._
 
-  implicit val executionContext = system.dispatcher
+  implicit val executionContext = system.dispatchers.lookup(Redis.dispatcher.name)
 
   implicit val timeout = Timeout(10 seconds)
   val timeOut = 10 seconds

--- a/src/test/scala/redis/RedisTest.scala
+++ b/src/test/scala/redis/RedisTest.scala
@@ -1,5 +1,7 @@
 package redis
 
+import akka.ConfigurationException
+
 import scala.concurrent._
 import akka.util.ByteString
 
@@ -39,6 +41,13 @@ class RedisTest extends RedisSpec {
         }
         Await.result(r, timeOut)
       })
+    }
+    "use custom dispatcher" in {
+      def test() = withRedisServer(port => {
+        implicit val redisDispatcher = RedisDispatcher("no-this-dispatcher")
+        RedisClient(port = port)
+      })
+      test must throwA[ConfigurationException]
     }
   }
 

--- a/src/test/scala/redis/actors/RedisClientActorSpec.scala
+++ b/src/test/scala/redis/actors/RedisClientActorSpec.scala
@@ -9,7 +9,7 @@ import org.specs2.mutable.{SpecificationLike, Tags}
 import org.specs2.time.NoTimeConversions
 import redis.api.connection.Ping
 import redis.api.strings.Get
-import redis.{Operation, Redis}
+import redis.{RedisDispatcher, Operation, Redis}
 
 import scala.collection.mutable
 import scala.concurrent.{Await, Promise}
@@ -45,7 +45,7 @@ class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike
 
     
       val redisClientActor = TestActorRef[RedisClientActorMock](Props(classOf[RedisClientActorMock], probeReplyDecoder.ref, probeMock.ref, getConnectOperations, onConnectStatus)
-        .withDispatcher(Redis.dispatcher))
+        .withDispatcher(Redis.dispatcher.name))
 
       val promise = Promise[String]()
       val op1 = Operation(Ping, promise)
@@ -86,7 +86,7 @@ class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike
       val probeMock = TestProbe()
 
       val redisClientActor = TestActorRef[RedisClientActorMock](Props(classOf[RedisClientActorMock], probeReplyDecoder.ref, probeMock.ref, getConnectOperations, onConnectStatus)
-        .withDispatcher(Redis.dispatcher))
+        .withDispatcher(Redis.dispatcher.name))
         .underlyingActor
 
       val promise3 = Promise[String]()
@@ -106,7 +106,7 @@ class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike
       val probeMock = TestProbe()
 
       val redisClientActorRef = TestActorRef[RedisClientActorMock](Props(classOf[RedisClientActorMock], probeReplyDecoder.ref, probeMock.ref, getConnectOperations, onConnectStatus)
-        .withDispatcher(Redis.dispatcher))
+        .withDispatcher(Redis.dispatcher.name))
       val redisClientActor = redisClientActorRef.underlyingActor
 
       val promiseSent = Promise[String]()
@@ -135,7 +135,7 @@ class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike
 
 class RedisClientActorMock(probeReplyDecoder: ActorRef, probeMock: ActorRef, getConnectOperations: () => Seq[Operation[_, _]], onConnectStatus: Boolean => Unit )
   extends RedisClientActor(new InetSocketAddress("localhost", 6379), getConnectOperations, onConnectStatus) {
-  override def initRepliesDecoder() = probeReplyDecoder
+  override def initRepliesDecoder(implicit redisDispatcher: RedisDispatcher) = probeReplyDecoder
 
   override def preStart() {
     // disable preStart of RedisWorkerIO

--- a/src/test/scala/redis/actors/RedisReplyDecoderSpec.scala
+++ b/src/test/scala/redis/actors/RedisReplyDecoderSpec.scala
@@ -31,7 +31,8 @@ class RedisReplyDecoderSpec
       val q = QueuePromises(mutable.Queue[Operation[_, _]]())
       q.queue.enqueue(operation)
 
-      val redisReplyDecoder = TestActorRef[RedisReplyDecoder](Props(classOf[RedisReplyDecoder]).withDispatcher(Redis.dispatcher))
+      val redisReplyDecoder = TestActorRef[RedisReplyDecoder](Props(classOf[RedisReplyDecoder])
+          .withDispatcher(Redis.dispatcher.name))
 
       redisReplyDecoder.underlyingActor.queuePromises must beEmpty
 
@@ -63,7 +64,8 @@ class RedisReplyDecoderSpec
     "can't decode" in within(timeout){
       val probeMock = TestProbe()
 
-      val redisClientActor = TestActorRef[RedisClientActorMock2](Props(classOf[RedisClientActorMock2], probeMock.ref).withDispatcher(Redis.dispatcher))
+      val redisClientActor = TestActorRef[RedisClientActorMock2](
+        Props(classOf[RedisClientActorMock2], probeMock.ref).withDispatcher(Redis.dispatcher.name))
       val promise = Promise[String]()
       redisClientActor ! Operation(Ping, promise)
       awaitAssert({
@@ -106,7 +108,8 @@ class RedisReplyDecoderSpec
       q.queue.enqueue(operation2)
       q.queue.enqueue(operation3)
 
-      val redisReplyDecoder = TestActorRef[RedisReplyDecoder](Props(classOf[RedisReplyDecoder]).withDispatcher(Redis.dispatcher))
+      val redisReplyDecoder = TestActorRef[RedisReplyDecoder](Props(classOf[RedisReplyDecoder])
+          .withDispatcher(Redis.dispatcher.name))
 
       redisReplyDecoder.underlyingActor.queuePromises must beEmpty
 

--- a/src/test/scala/redis/actors/RedisSubscriberActorSpec.scala
+++ b/src/test/scala/redis/actors/RedisSubscriberActorSpec.scala
@@ -25,7 +25,7 @@ class RedisSubscriberActorSpec extends TestKit(ActorSystem()) with Specification
 
       val subscriberActor = TestActorRef[SubscriberActor](Props(classOf[SubscriberActor],
         new InetSocketAddress("localhost", 6379), channels, patterns, probeMock.ref)
-        .withDispatcher(Redis.dispatcher))
+        .withDispatcher(Redis.dispatcher.name))
 
       val connectMsg = probeMock.expectMsgType[Connect]
       connectMsg mustEqual Connect(subscriberActor.underlyingActor.address, options = SO.KeepAlive(on = true) :: Nil)

--- a/src/test/scala/redis/actors/RedisWorkerIOSpec.scala
+++ b/src/test/scala/redis/actors/RedisWorkerIOSpec.scala
@@ -27,7 +27,7 @@ class RedisWorkerIOSpec extends TestKit(ActorSystem()) with SpecificationLike wi
       val probeTcp = TestProbe()
       val probeMock = TestProbe()
 
-      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, ByteString.empty).withDispatcher(Redis.dispatcher))
+      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, ByteString.empty).withDispatcher(Redis.dispatcher.name))
 
       val connectMsg = probeTcp.expectMsgType[Connect]
       connectMsg mustEqual Connect(address, options = SO.KeepAlive(on = true) :: Nil)
@@ -51,7 +51,7 @@ class RedisWorkerIOSpec extends TestKit(ActorSystem()) with SpecificationLike wi
       val probeTcp = TestProbe()
       val probeMock = TestProbe()
 
-      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, ByteString.empty).withDispatcher(Redis.dispatcher))
+      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, ByteString.empty).withDispatcher(Redis.dispatcher.name))
 
       redisWorkerIO ! "PING1"
 
@@ -82,7 +82,7 @@ class RedisWorkerIOSpec extends TestKit(ActorSystem()) with SpecificationLike wi
       val probeTcp = TestProbe()
       val probeMock = TestProbe()
 
-      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, ByteString.empty).withDispatcher(Redis.dispatcher))
+      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, ByteString.empty).withDispatcher(Redis.dispatcher.name))
 
       redisWorkerIO ! "PING1"
 
@@ -119,7 +119,7 @@ class RedisWorkerIOSpec extends TestKit(ActorSystem()) with SpecificationLike wi
       val probeTcp = TestProbe()
       val probeMock = TestProbe()
 
-      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, ByteString.empty).withDispatcher(Redis.dispatcher))
+      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, ByteString.empty).withDispatcher(Redis.dispatcher.name))
 
       redisWorkerIO ! "PING1"
 
@@ -142,7 +142,7 @@ class RedisWorkerIOSpec extends TestKit(ActorSystem()) with SpecificationLike wi
       val probeTcp = TestProbe()
       val probeMock = TestProbe()
 
-      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, ByteString.empty).withDispatcher(Redis.dispatcher))
+      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, ByteString.empty).withDispatcher(Redis.dispatcher.name))
 
       redisWorkerIO ! "PING1"
 
@@ -164,7 +164,7 @@ class RedisWorkerIOSpec extends TestKit(ActorSystem()) with SpecificationLike wi
       val probeTcp = TestProbe()
       val probeMock = TestProbe()
 
-      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, ByteString.empty).withDispatcher(Redis.dispatcher))
+      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, ByteString.empty).withDispatcher(Redis.dispatcher.name))
 
       redisWorkerIO ! "PING1"
 
@@ -217,7 +217,7 @@ class RedisWorkerIOSpec extends TestKit(ActorSystem()) with SpecificationLike wi
       val probeMock = TestProbe()
       val onConnectByteString = ByteString("on connect write")
 
-      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, onConnectByteString).withDispatcher(Redis.dispatcher))
+      val redisWorkerIO = TestActorRef[RedisWorkerIOMock](Props(classOf[RedisWorkerIOMock], probeTcp.ref, address, probeMock.ref, onConnectByteString).withDispatcher(Redis.dispatcher.name))
 
 
       val connectMsg = probeTcp.expectMsgType[Connect]


### PR DESCRIPTION
This resolves #122 . The change of executeContext may break backward compatibility, so I will change that in another PR.