### PR TITLE
fix implicit redis dispatcher in RedisClientActor

### DIFF
--- a/src/main/scala/redis/Redis.scala
+++ b/src/main/scala/redis/Redis.scala
@@ -32,7 +32,8 @@ abstract class RedisClientActorLike(system: ActorSystem, redisDispatcher: RedisD
   implicit val executionContext = system.dispatchers.lookup(redisDispatcher.name)
 
   val redisConnection: ActorRef = system.actorOf(
-    Props(classOf[RedisClientActor], new InetSocketAddress(host, port), getConnectOperations, onConnectStatus )
+    Props(classOf[RedisClientActor], new InetSocketAddress(host, port), getConnectOperations,
+      onConnectStatus, redisDispatcher.name)
       .withDispatcher(redisDispatcher.name),
     name + '-' + Redis.tempName()
   )
@@ -51,7 +52,7 @@ abstract class RedisClientActorLike(system: ActorSystem, redisDispatcher: RedisD
   }
 
   def onConnectStatus(): (Boolean) => Unit = (status: Boolean) => {
-    
+
   }
 
   def getConnectOperations: () => Seq[Operation[_, _]] = () => {
@@ -135,7 +136,7 @@ case class RedisPubSub(
   }
 
   def onConnectStatus(): (Boolean) => Unit = (status: Boolean) => {
-    
+
   }
 }
 

--- a/src/main/scala/redis/RedisPool.scala
+++ b/src/main/scala/redis/RedisPool.scala
@@ -78,7 +78,8 @@ abstract class RedisClientPoolLike(system: ActorSystem, redisDispatcher: RedisDi
 
   def makeRedisClientActor(server: RedisServer, active: Ref[Boolean]): ActorRef = {
     system.actorOf(
-      Props(classOf[RedisClientActor], new InetSocketAddress(server.host, server.port), getConnectOperations(server), onConnectStatus(server, active))
+      Props(classOf[RedisClientActor], new InetSocketAddress(server.host, server.port),
+        getConnectOperations(server), onConnectStatus(server, active), redisDispatcher.name)
         .withDispatcher(redisDispatcher.name),
       name + '-' + Redis.tempName()
     )

--- a/src/main/scala/redis/actors/RedisClientActor.scala
+++ b/src/main/scala/redis/actors/RedisClientActor.scala
@@ -7,7 +7,8 @@ import akka.actor._
 import scala.collection.mutable
 import akka.actor.SupervisorStrategy.Stop
 
-class RedisClientActor(override val address: InetSocketAddress, getConnectOperations: () => Seq[Operation[_, _]], onConnectStatus: Boolean => Unit  ) extends RedisWorkerIO(address,onConnectStatus) {
+class RedisClientActor(override val address: InetSocketAddress, getConnectOperations: () =>
+    Seq[Operation[_, _]], onConnectStatus: Boolean => Unit, dispatcherName: String) extends RedisWorkerIO(address,onConnectStatus) {
 
 
   import context._
@@ -17,8 +18,8 @@ class RedisClientActor(override val address: InetSocketAddress, getConnectOperat
   // connection closed on the sending direction
   var oldRepliesDecoder: Option[ActorRef] = None
 
-  def initRepliesDecoder(implicit redisDispatcher: RedisDispatcher = Redis.dispatcher) =
-    context.actorOf(Props(classOf[RedisReplyDecoder]).withDispatcher(redisDispatcher.name))
+  def initRepliesDecoder() =
+    context.actorOf(Props(classOf[RedisReplyDecoder]).withDispatcher(dispatcherName))
 
   var queuePromises = mutable.Queue[Operation[_, _]]()
 

--- a/src/test/scala/redis/actors/RedisClientActorSpec.scala
+++ b/src/test/scala/redis/actors/RedisClientActorSpec.scala
@@ -43,7 +43,7 @@ class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike
         Seq(opConnectPing, opConnectGet)
       }
 
-    
+
       val redisClientActor = TestActorRef[RedisClientActorMock](Props(classOf[RedisClientActorMock], probeReplyDecoder.ref, probeMock.ref, getConnectOperations, onConnectStatus)
         .withDispatcher(Redis.dispatcher.name))
 
@@ -134,8 +134,8 @@ class RedisClientActorSpec extends TestKit(ActorSystem()) with SpecificationLike
 }
 
 class RedisClientActorMock(probeReplyDecoder: ActorRef, probeMock: ActorRef, getConnectOperations: () => Seq[Operation[_, _]], onConnectStatus: Boolean => Unit )
-  extends RedisClientActor(new InetSocketAddress("localhost", 6379), getConnectOperations, onConnectStatus) {
-  override def initRepliesDecoder(implicit redisDispatcher: RedisDispatcher) = probeReplyDecoder
+  extends RedisClientActor(new InetSocketAddress("localhost", 6379), getConnectOperations, onConnectStatus, Redis.dispatcher.name) {
+  override def initRepliesDecoder() = probeReplyDecoder
 
   override def preStart() {
     // disable preStart of RedisWorkerIO

--- a/src/test/scala/redis/actors/RedisReplyDecoderSpec.scala
+++ b/src/test/scala/redis/actors/RedisReplyDecoderSpec.scala
@@ -164,7 +164,7 @@ class RedisReplyDecoderSpec
 }
 
 class RedisClientActorMock2(probeMock: ActorRef)
-  extends RedisClientActor(new InetSocketAddress("localhost", 6379), () => {Seq()}, (status:Boolean) => {()} ) {
+  extends RedisClientActor(new InetSocketAddress("localhost", 6379), () => {Seq()}, (status:Boolean) => {()}, Redis.dispatcher.name) {
   override def preStart() {
     // disable preStart of RedisWorkerIO
   }


### PR DESCRIPTION
Sorry, in #123, `initRepliesDecoder` in `RedisClientActor` doesn't pick up implicit value. This fixes it. And I test it with JProfiler. It should be right now.