### PR TITLE
Fixes #129 Implement ZADD options

### DIFF
--- a/src/main/scala/redis/api/SortedSets.scala
+++ b/src/main/scala/redis/api/SortedSets.scala
@@ -1,16 +1,18 @@
 package redis.api.sortedsets
 
-import redis._
 import akka.util.ByteString
-import redis.api.{SUM, Aggregate, Limit}
+import redis._
+import redis.api.{Aggregate, Limit, SUM, ZaddOption}
 import redis.protocol.RedisReply
 
-case class Zadd[K, V](key: K, scoreMembers: Seq[(Double, V)])(implicit keySeria: ByteStringSerializer[K], convert: ByteStringSerializer[V])
+case class Zadd[K, V](key: K, options: Seq[ZaddOption], scoreMembers: Seq[(Double, V)])
+                     (implicit keySeria: ByteStringSerializer[K], convert: ByteStringSerializer[V])
   extends RedisCommandIntegerLong {
   val isMasterOnly = true
-  val encodedRequest: ByteString = encode("ZADD", keySeria.serialize(key) +: scoreMembers.foldLeft(Seq.empty[ByteString])({
-    case (acc, e) => ByteString(e._1.toString) +: convert.serialize(e._2) +: acc
-  }))
+  val encodedRequest: ByteString = encode("ZADD", keySeria.serialize(key) +: (options.map(_.serialize) ++
+    scoreMembers.foldLeft(Seq.empty[ByteString])({
+      case (acc, e) => ByteString(e._1.toString) +: convert.serialize(e._2) +: acc
+    })))
 }
 
 case class Zcard[K](key: K)(implicit keySeria: ByteStringSerializer[K]) extends RedisCommandIntegerLong {

--- a/src/main/scala/redis/api/api.scala
+++ b/src/main/scala/redis/api/api.scala
@@ -49,3 +49,28 @@ sealed trait ShutdownModifier
 case object SAVE extends ShutdownModifier
 
 case object NOSAVE extends ShutdownModifier
+
+
+sealed trait ZaddOption {
+  def serialize: ByteString
+}
+
+object ZaddOption {
+
+  case object XX extends ZaddOption {
+    override def serialize: ByteString = ByteString("XX")
+  }
+
+  case object NX extends ZaddOption {
+    override def serialize: ByteString = ByteString("NX")
+  }
+
+  case object CH extends ZaddOption {
+    override def serialize: ByteString = ByteString("CH")
+  }
+
+  case object INCR extends ZaddOption {
+    override def serialize: ByteString = ByteString("INCR")
+  }
+
+}

--- a/src/main/scala/redis/commands/SortedSets.scala
+++ b/src/main/scala/redis/commands/SortedSets.scala
@@ -1,14 +1,18 @@
 package redis.commands
 
-import redis.{Cursor, ByteStringDeserializer, ByteStringSerializer, Request}
-import scala.concurrent.Future
 import redis.api._
 import redis.api.sortedsets._
+import redis.{ByteStringDeserializer, ByteStringSerializer, Cursor, Request}
+
+import scala.concurrent.Future
 
 trait SortedSets extends Request {
 
   def zadd[V: ByteStringSerializer](key: String, scoreMembers: (Double, V)*): Future[Long] =
-    send(Zadd(key, scoreMembers))
+    send(Zadd(key, Seq.empty, scoreMembers))
+
+  def zaddWithOptions[V: ByteStringSerializer](key: String, options: Seq[ZaddOption], scoreMembers: (Double, V)*): Future[Long] =
+    send(Zadd(key, options, scoreMembers))
 
   def zcard(key: String): Future[Long] =
     send(Zcard(key))

--- a/src/test/scala/redis/commands/SortedSetsSpec.scala
+++ b/src/test/scala/redis/commands/SortedSetsSpec.scala
@@ -2,7 +2,9 @@ package redis.commands
 
 import redis._
 import redis.api._
-import scala.concurrent.Await
+import redis.api.ZaddOption.{CH, NX, XX}
+
+import scala.concurrent.{Await, Future}
 import akka.util.ByteString
 
 class SortedSetsSpec extends RedisSpec {
@@ -10,14 +12,21 @@ class SortedSetsSpec extends RedisSpec {
   "Sorted Sets commands" should {
     "ZADD" in {
       val r = for {
+        version <- redisVersion()
+        ge_3_0_2 = version.exists(_ >= RedisVersion(3, 0, 2))
         _ <- redis.del("zaddKey")
         z1 <- redis.zadd("zaddKey", 1.0 -> "one", (1, "uno"), (2, "two"))
         z2 <- redis.zadd("zaddKey", (3, "two"))
+        z3 <- if (ge_3_0_2) redis.zaddWithOptions("zaddKey", Seq(XX, CH), 0.9 -> "one", (3, "three")) else Future.successful(1)
+        z4 <- if (ge_3_0_2) redis.zaddWithOptions("zaddKey", Seq(NX), 0.8 -> "one", (4, "three")) else Future.successful(1)
+        _ <- redis.zadd("zaddKey", 1.0 -> "one", (4, "three"))
         zr <- redis.zrangeWithscores("zaddKey", 0, -1)
       } yield {
         z1 mustEqual 3
         z2 mustEqual 0
-        zr mustEqual Seq((ByteString("one"), 1), (ByteString("uno"), 1), (ByteString("two"), 3))
+        z3 mustEqual 1
+        z4 mustEqual 1
+        zr mustEqual Seq((ByteString("one"), 1.0), (ByteString("uno"), 1), (ByteString("two"), 3), (ByteString("three"), 4))
       }
       Await.result(r, timeOut)
     }
@@ -155,16 +164,16 @@ class SortedSetsSpec extends RedisSpec {
     "ZREMRANGEBYLEX" in {
       val r = for {
         _ <- redis.del("zremrangebylexKey")
-        z1 <- redis.zadd("zremrangebylexKey", 0d -> "a",  0d -> "b", 0d -> "c", 0d -> "d", 0d -> "e", 0d -> "f", 0d -> "g")
+        z1 <- redis.zadd("zremrangebylexKey", 0d -> "a", 0d -> "b", 0d -> "c", 0d -> "d", 0d -> "e", 0d -> "f", 0d -> "g")
         z2 <- redis.zremrangebylex("zremrangebylexKey", "[z", "[d")
         z3 <- redis.zremrangebylex("zremrangebylexKey", "[b", "[d")
         zrange1 <- redis.zrange("zremrangebylexKey", 0, -1)
       } yield {
-          z1 mustEqual 7
-          z2 mustEqual 0
-          z3 mustEqual 3
-          zrange1 mustEqual Seq(ByteString("a"), ByteString("e"), ByteString("f"), ByteString("g"))
-        }
+        z1 mustEqual 7
+        z2 mustEqual 0
+        z3 mustEqual 3
+        zrange1 mustEqual Seq(ByteString("a"), ByteString("e"), ByteString("f"), ByteString("g"))
+      }
       Await.result(r, timeOut)
     }
 


### PR DESCRIPTION
In order to preserve backward compatibility for Int -> Double implicit
conversion in zadd score parameters, a new zaddWithOptions has been
added instead of overloading zadd function.
