### PR TITLE
name property for RedisServer

### DIFF
--- a/src/main/scala/redis/RedisPool.scala
+++ b/src/main/scala/redis/RedisPool.scala
@@ -13,7 +13,8 @@ import redis.commands.Transactions
 case class RedisServer(host: String = "localhost",
                        port: Int = 6379,
                        password: Option[String] = None,
-                       db: Option[Int] = None)
+                       db: Option[Int] = None,
+                       name: String = "")
 
 
 case class RedisConnection(actor: ActorRef, active: Ref[Boolean] = Ref(false))


### PR DESCRIPTION
Add name property for RedisServer, so it's possible to add multi connection in the pool for a single server.