### PR TITLE
Update Scala-2.11.8 and Akka-2.4.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ script: "sbt clean coverage test"
 after_script:
   - "sbt coveralls"
 scala:
-  - "2.11.7"
+  - "2.11.8"
 jdk:
-  - oraclejdk7
-  - openjdk7
+  - oraclejdk8
 services:
   - redis
 env:

--- a/project/Rediscala.scala
+++ b/project/Rediscala.scala
@@ -17,7 +17,7 @@ object Resolvers {
 }
 
 object Dependencies {
-  val akkaVersion = "2.3.6"
+  val akkaVersion = "2.4.10"
 
   import sbt._
 
@@ -51,8 +51,7 @@ object RediscalaBuild extends Build {
     Seq(
       name := "rediscala",
       organization := "com.github.etaty",
-      scalaVersion := "2.11.7",
-      crossScalaVersions := Seq("2.11.7", "2.10.4"),
+      scalaVersion := "2.11.8",
       licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
       homepage := Some(url("https://github.com/non/rediscala")),
       scmInfo := Some(ScmInfo(url("https://github.com/etaty/rediscala"), "scm:git:git@github.com:etaty/rediscala.git")),
@@ -146,7 +145,7 @@ object RediscalaBuild extends Build {
       id = "benchmark",
       base = file("benchmark")
     ).settings(Seq(
-      scalaVersion := "2.11.7",
+      scalaVersion := "2.11.8",
       libraryDependencies += "net.debasishg" %% "redisclient" % "3.0"
     ))
       .enablePlugins(JmhPlugin)

--- a/src/test/scala/redis/RedisSpec.scala
+++ b/src/test/scala/redis/RedisSpec.scala
@@ -31,7 +31,7 @@ abstract class RedisHelper extends TestKit(ActorSystem()) with SpecificationLike
     Step(setup()) ^
       fs ^
       Step({
-        system.shutdown()
+        system.terminate()
         cleanup()
       })
   }


### PR DESCRIPTION
Update Scala-2.11.8 and Akka-2.4.10
- Drop Scala-2.10.x support
- JDK8 support only
