### PR TITLE
Add binary-safe alternatives for eval

### DIFF
--- a/src/main/scala/redis/commands/Scripting.scala
+++ b/src/main/scala/redis/commands/Scripting.scala
@@ -11,16 +11,28 @@ trait Scripting extends Request {
    * Try EVALSHA, if NOSCRIPT returned, fallback to EVAL
    */
   def evalshaOrEval[R: RedisReplyDeserializer](redisScript: RedisScript, keys: Seq[String] = Seq.empty[String], args: Seq[String] = Seq.empty[String]): Future[R] = {
-    evalsha(redisScript.sha1, keys, args).recoverWith({
-      case ReplyErrorException(message) if message.startsWith("NOSCRIPT") => eval(redisScript.script, keys, args)
+    evalshaOrEvalBinary(redisScript, keys, args)
+  }
+
+  def evalshaOrEvalBinary[R: RedisReplyDeserializer, KK: ByteStringSerializer, KA: ByteStringSerializer](redisScript: RedisScript, keys: Seq[KK], args: Seq[KA]): Future[R] = {
+    evalshaBinary(redisScript.sha1, keys, args).recoverWith({
+      case ReplyErrorException(message) if message.startsWith("NOSCRIPT") => evalBinary(redisScript.script, keys, args)
     })
   }
 
   def eval[R: RedisReplyDeserializer](script: String, keys: Seq[String] = Seq.empty[String], args: Seq[String] = Seq.empty[String]): Future[R] = {
+    evalBinary(script, keys, args)
+  }
+
+  def evalBinary[R: RedisReplyDeserializer, KK: ByteStringSerializer, KA: ByteStringSerializer](script: String, keys: Seq[KK], args: Seq[KA]): Future[R] = {
     send(Eval(script, keys, args))
   }
 
   def evalsha[R: RedisReplyDeserializer](sha1: String, keys: Seq[String] = Seq.empty[String], args: Seq[String] = Seq.empty[String]): Future[R] = {
+    evalshaBinary(sha1, keys, args)
+  }
+
+  def evalshaBinary[R: RedisReplyDeserializer, KK: ByteStringSerializer, KA: ByteStringSerializer](sha1: String, keys: Seq[KK], args: Seq[KA]): Future[R] = {
     send(Evalsha(sha1, keys, args))
   }
 
@@ -40,6 +52,3 @@ trait Scripting extends Request {
     send(ScriptExists(sha1))
   }
 }
-
-
-

--- a/src/test/scala/redis/commands/ScriptingSpec.scala
+++ b/src/test/scala/redis/commands/ScriptingSpec.scala
@@ -26,6 +26,12 @@ class ScriptingSpec(implicit ee: ExecutionEnv) extends RedisStandaloneServer {
       r mustEqual MultiBulk(Some(Vector(Bulk(Some(ByteString("key"))), Bulk(Some(ByteString("arg"))))))
     }
 
+    "evalshaOrEvalBinary" in {
+      Await.result(redis.scriptFlush(), timeOut) must beTrue
+      val r = Await.result(redis.evalshaOrEvalBinary(redisScriptKeysArgs, Seq("key"), Seq(ByteString(255))), timeOut)
+      r mustEqual MultiBulk(Some(Vector(Bulk(Some(ByteString("key"))), Bulk(Some(ByteString(255))))))
+    }
+
     "EVAL" in {
       Await.result(redis.eval(redisScript.script), timeOut) mustEqual Bulk(Some(ByteString("rediscala")))
     }


### PR DESCRIPTION
Currently the only externally accessible commands for EVAL and friends take Seq[String] for keys and arguments. String can only contain valid UTF-8 sequences, which makes it impossible to send arbitrary binary data to a Lua script, for example to do a compare-and-set of compressed data.

This exposes a new evalBinary method and related equivalents that expose the ability for an application to provide its own ByteStringSerializer instances for arguments to scripts. Note these can't easily be written as simple overloads because the erased type of the arguments (Seq[_]) would be identical to the existing Seq[String] methods.