### PR TITLE
Add support for Redis 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ Session.vim
 .DS_Store
 *.rdb
 *.aof
-redis-3.2.0/
-redis-3.2.0.tar.gz
+redis-4.0.14/
+redis-4.0.14.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 env:
   global:  
     - SBT_OPTS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:PermSize=256M -XX:MaxPermSize=512M"
-    - REDIS_HOME=redis-3.2.0/src
+    - REDIS_HOME=redis-4.0.14/src
 # whitelist
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 env:
   global:  
     - SBT_OPTS="-XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:PermSize=256M -XX:MaxPermSize=512M"
-    - REDIS_HOME=redis-4.0.14/src
+    - REDIS_HOME=redis-5.0.5/src
 # whitelist
 branches:
   only:

--- a/install-redis.sh
+++ b/install-redis.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -ex
-wget http://download.redis.io/releases/redis-4.0.14.tar.gz
-tar -xzvf redis-4.0.14.tar.gz
-cd redis-4.0.14 && make
+wget http://download.redis.io/releases/redis-5.0.5.tar.gz
+tar -xzvf redis-5.0.5.tar.gz
+cd redis-5.0.5 && make

--- a/install-redis.sh
+++ b/install-redis.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -ex
-wget http://download.redis.io/releases/redis-3.2.0.tar.gz
-tar -xzvf redis-3.2.0.tar.gz
-cd redis-3.2.0 && make
+wget http://download.redis.io/releases/redis-4.0.14.tar.gz
+tar -xzvf redis-4.0.14.tar.gz
+cd redis-4.0.14 && make

--- a/src/main/scala/redis/Converter.scala
+++ b/src/main/scala/redis/Converter.scala
@@ -100,6 +100,12 @@ object MultiBulkConverter {
     }).getOrElse(None)
   }
 
+  def toOptionStringByteStringDouble[R](reply: MultiBulk)(implicit deserializer: ByteStringDeserializer[R]): Option[(String, R, Double)] = {
+    reply.responses.map(r => {
+      Some((r(0).toString, deserializer.deserialize(r(1).toByteString), r(2).toByteString.utf8String.toDouble))
+    }).getOrElse(None)
+  }
+
   def toSeqBoolean(reply: MultiBulk): Seq[Boolean] = {
     reply.responses.map(r => {
       r.map(_.toString == "1")

--- a/src/main/scala/redis/Redis.scala
+++ b/src/main/scala/redis/Redis.scala
@@ -25,6 +25,7 @@ trait RedisCommands
   with HyperLogLog
   with Clusters
   with Geo
+  with Streams
 
 trait RedisBlockingCommands
   extends BLists

--- a/src/main/scala/redis/Redis.scala
+++ b/src/main/scala/redis/Redis.scala
@@ -26,6 +26,10 @@ trait RedisCommands
   with Clusters
   with Geo
 
+trait RedisBlockingCommands
+  extends BLists
+  with BSortedSets
+
 abstract class RedisClientActorLike(system: ActorSystem, redisDispatcher: RedisDispatcher, connectTimeout: Option[FiniteDuration] = None) extends ActorRequest {
   var host: String
   var port: Int
@@ -94,7 +98,7 @@ case class RedisBlockingClient(var host: String = "localhost",
                                connectTimeout: Option[FiniteDuration] = None)
                               (implicit _system: ActorSystem,
                                redisDispatcher: RedisDispatcher = Redis.dispatcher
-                              ) extends RedisClientActorLike(_system, redisDispatcher, connectTimeout) with BLists {
+                              ) extends RedisClientActorLike(_system, redisDispatcher, connectTimeout) with RedisBlockingCommands {
 }
 
 case class RedisPubSub(

--- a/src/main/scala/redis/api/BSortedSets.scala
+++ b/src/main/scala/redis/api/BSortedSets.scala
@@ -1,0 +1,23 @@
+package redis.api.bsortedsets
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import redis._
+import akka.util.ByteString
+import redis.protocol.MultiBulk
+
+case class Bzpopmax[KK: ByteStringSerializer, R: ByteStringDeserializer](keys: Seq[KK], timeout: FiniteDuration = Duration.Zero)
+  extends Bzpopx[KK, R]("BZPOPMAX")
+
+case class Bzpopmin[KK: ByteStringSerializer, R: ByteStringDeserializer](keys: Seq[KK], timeout: FiniteDuration = Duration.Zero)
+  extends Bzpopx[KK, R]("BZPOPMIN")
+
+private[redis] abstract class Bzpopx[KK, R](command: String)(implicit redisKeys: ByteStringSerializer[KK], deserializerR: ByteStringDeserializer[R])
+  extends RedisCommandMultiBulk[Option[(String, R, Double)]] {
+  val isMasterOnly = true
+  val keys: Seq[KK]
+  val timeout: FiniteDuration
+
+  val encodedRequest: ByteString = encode(command, keys.map(redisKeys.serialize) ++ Seq(ByteString(timeout.toSeconds.toString)))
+
+  def decodeReply(mb: MultiBulk) = MultiBulkConverter.toOptionStringByteStringDouble(mb)
+}

--- a/src/main/scala/redis/api/Connection.scala
+++ b/src/main/scala/redis/api/Connection.scala
@@ -31,3 +31,8 @@ case class Select(index: Int) extends RedisCommandStatusBoolean {
   val isMasterOnly = true
   val encodedRequest: ByteString = encode("SELECT", Seq(ByteString(index.toString)))
 }
+
+case class Swapdb(index1: Int, index2: Int) extends RedisCommandStatusBoolean {
+  val isMasterOnly = true
+  val encodedRequest: ByteString = encode("SWAPDB", Seq(ByteString(index1.toString), ByteString(index2.toString)))
+}

--- a/src/main/scala/redis/api/Keys.scala
+++ b/src/main/scala/redis/api/Keys.scala
@@ -189,3 +189,10 @@ case class Scan[C](cursor: C, count: Option[Int], matchGlob: Option[String])(imp
 
   val empty: Seq[String] = Seq.empty
 }
+
+case class Unlink[K](keys: Seq[K])(implicit redisKey: ByteStringSerializer[K]) extends MultiClusterKey[K] with RedisCommandIntegerLong {
+  val isMasterOnly = true
+  val encodedRequest: ByteString = encode("UNLINK", keys.map(redisKey.serialize))
+}
+
+

--- a/src/main/scala/redis/api/Keys.scala
+++ b/src/main/scala/redis/api/Keys.scala
@@ -46,17 +46,32 @@ case class Keys(pattern: String) extends RedisCommandMultiBulk[Seq[String]] {
   def decodeReply(mb: MultiBulk) = MultiBulkConverter.toSeqString(mb)
 }
 
-case class Migrate[K](host: String, port: Int, key: K, destinationDB: Int, timeout: FiniteDuration)(implicit redisKey: ByteStringSerializer[K])
+case class Migrate[K](host: String, port: Int, keys: Seq[K], destinationDB: Int, timeout: FiniteDuration, copy: Boolean = false, replace: Boolean = false, password: Option[String])(implicit redisKey: ByteStringSerializer[K])
   extends RedisCommandStatusBoolean {
   val isMasterOnly = true
-  val encodedRequest: ByteString =
-    encode("MIGRATE",
-      Seq(ByteString(host),
-        ByteString(port.toString),
-        redisKey.serialize(key),
-        ByteString(destinationDB.toString),
-        ByteString(timeout.toMillis.toString)
-      ))
+  val encodedRequest: ByteString = {
+    val builder = Seq.newBuilder[ByteString]
+
+    builder += ByteString(host)
+    builder += ByteString(port.toString)
+    builder += ByteString("")
+    builder += ByteString(destinationDB.toString)
+    builder += ByteString(timeout.toMillis.toString)
+
+    if (copy)
+      builder += ByteString("COPY")
+    if (replace)
+      builder += ByteString("REPLACE")
+    if (password.isDefined) {
+      builder += ByteString("AUTH")
+      builder += ByteString(password.get)
+    }
+
+    builder += ByteString("KEYS")
+    builder ++= keys.map(redisKey.serialize)
+
+    RedisProtocolRequest.multiBulk("MIGRATE", builder.result())
+  }
 }
 
 case class Move[K](key: K, db: Int)(implicit redisKey: ByteStringSerializer[K]) extends SimpleClusterKey[K] with RedisCommandIntegerBoolean {

--- a/src/main/scala/redis/api/Lists.scala
+++ b/src/main/scala/redis/api/Lists.scala
@@ -35,9 +35,9 @@ case class Lpush[K, V](key: K, values: Seq[V])(implicit redisKey: ByteStringSeri
 }
 
 
-case class Lpushx[K, V](key: K, value: V)(implicit redisKey: ByteStringSerializer[K], convert: ByteStringSerializer[V]) extends SimpleClusterKey[K] with RedisCommandIntegerLong {
+case class Lpushx[K, V](key: K, values: Seq[V])(implicit redisKey: ByteStringSerializer[K], convert: ByteStringSerializer[V]) extends SimpleClusterKey[K] with RedisCommandIntegerLong {
   val isMasterOnly = true
-  val encodedRequest: ByteString = encode("LPUSHX", Seq(keyAsString, convert.serialize(value)))
+  val encodedRequest: ByteString = encode("LPUSHX", keyAsString +: values.map(v => convert.serialize(v)))
 }
 
 case class Lrange[K, R](key: K, start: Long, stop: Long)(implicit redisKey: ByteStringSerializer[K], deserializerR: ByteStringDeserializer[R]) extends SimpleClusterKey[K] with RedisCommandMultiBulk[Seq[R]] {
@@ -83,7 +83,7 @@ case class Rpush[K, V](key: K, values: Seq[V])(implicit redisKey: ByteStringSeri
   val encodedRequest: ByteString = encode("RPUSH", keyAsString +: values.map(v => convert.serialize(v)))
 }
 
-case class Rpushx[K, V](key: K, value: V)(implicit redisKey: ByteStringSerializer[K], convert: ByteStringSerializer[V]) extends SimpleClusterKey[K] with RedisCommandIntegerLong {
+case class Rpushx[K, V](key: K, values: Seq[V])(implicit redisKey: ByteStringSerializer[K], convert: ByteStringSerializer[V]) extends SimpleClusterKey[K] with RedisCommandIntegerLong {
   val isMasterOnly = true
-  val encodedRequest: ByteString = encode("RPUSHX", Seq(keyAsString, convert.serialize(value)))
+  val encodedRequest: ByteString = encode("RPUSHX", keyAsString +: values.map(v => convert.serialize(v)))
 }

--- a/src/main/scala/redis/api/Servers.scala
+++ b/src/main/scala/redis/api/Servers.scala
@@ -81,14 +81,14 @@ case object DebugSegfault extends RedisCommandStatusString {
   val encodedRequest: ByteString = encode("DEBUG SEGFAULT")
 }
 
-case object Flushall extends RedisCommandStatusBoolean {
+case class Flushall(async: Boolean = false) extends RedisCommandStatusBoolean {
   val isMasterOnly: Boolean = true
-  val encodedRequest: ByteString = encode("FLUSHALL")
+  val encodedRequest: ByteString = encode("FLUSHALL", if (async) Seq(ByteString("ASYNC")) else Seq.empty)
 }
 
-case object Flushdb extends RedisCommandStatusBoolean {
+case class Flushdb(async: Boolean = false) extends RedisCommandStatusBoolean {
   val isMasterOnly: Boolean = true
-  val encodedRequest: ByteString = encode("FLUSHDB")
+  val encodedRequest: ByteString = encode("FLUSHDB", if (async) Seq(ByteString("ASYNC")) else Seq.empty)
 }
 
 case class Info(section: Option[String] = None) extends RedisCommandBulk[String] {

--- a/src/main/scala/redis/api/SortedSets.scala
+++ b/src/main/scala/redis/api/SortedSets.scala
@@ -64,6 +64,20 @@ case class ZinterstoreWeighted[KD: ByteStringSerializer, K: ByteStringSerializer
   val encodedRequest: ByteString = encode("ZINTERSTORE", ZstoreWeighted.buildArgs(destination, keys, aggregate))
 }
 
+case class Zpopmax[K, R](key: K, count: Option[Long])(implicit keySeria: ByteStringSerializer[K], deserializerR: ByteStringDeserializer[R])
+  extends SimpleClusterKey[K] with RedisCommandMultiBulkSeqByteStringDouble[R] {
+  val isMasterOnly = true
+  val encodedRequest: ByteString = encode("ZPOPMAX", Seq(keyAsString) ++ count.map(c => ByteString(c.toString)))
+  val deserializer: ByteStringDeserializer[R] = deserializerR
+}
+
+case class Zpopmin[K, R](key: K, count: Option[Long])(implicit keySeria: ByteStringSerializer[K], deserializerR: ByteStringDeserializer[R])
+  extends SimpleClusterKey[K] with RedisCommandMultiBulkSeqByteStringDouble[R] {
+  val isMasterOnly = true
+  val encodedRequest: ByteString = encode("ZPOPMIN", Seq(keyAsString) ++ count.map(c => ByteString(c.toString)))
+  val deserializer: ByteStringDeserializer[R] = deserializerR
+}
+
 case class Zrange[K, R](key: K, start: Long, stop: Long)(implicit keySeria: ByteStringSerializer[K], deserializerR: ByteStringDeserializer[R])
   extends SimpleClusterKey[K] with RedisCommandMultiBulkSeqByteString[R] {
   val encodedRequest: ByteString = encode("ZRANGE", Seq(keyAsString, ByteString(start.toString), ByteString(stop.toString)))

--- a/src/main/scala/redis/api/Streams.scala
+++ b/src/main/scala/redis/api/Streams.scala
@@ -1,0 +1,126 @@
+package redis.api.streams
+
+import akka.util.ByteString
+import redis._
+import redis.api.{RequestStreamId, StreamEntry, StreamId, TrimStrategy}
+import redis.protocol.{Bulk, MultiBulk, RedisReply}
+
+case class Xadd[K, F, V](key: K, id: RequestStreamId, fields: Seq[(F, V)], trimStrategy: Option[TrimStrategy])(implicit serializerK: ByteStringSerializer[K], serializerF: ByteStringSerializer[F], serializerV: ByteStringSerializer[V])
+  extends SimpleClusterKey[K] with RedisCommandBulk[StreamId] {
+  val isMasterOnly = true
+
+  val encodedRequest: ByteString = {
+    val builder = Seq.newBuilder[ByteString]
+
+    builder += keyAsString
+
+    if (trimStrategy.isDefined) {
+      builder ++= trimStrategy.get.toByteString
+    }
+
+    builder += id.serialize
+
+    fields.foreach { f =>
+      builder += serializerF.serialize(f._1)
+      builder += serializerV.serialize(f._2)
+    }
+
+    encode("XADD", builder.result())
+  }
+
+  def decodeReply(bulk: Bulk): StreamId = bulk.response.map(StreamId.deserialize).get
+}
+
+case class Xdel[K](key: K, ids: Seq[StreamId])(implicit serializerK: ByteStringSerializer[K])
+  extends SimpleClusterKey[K] with RedisCommandIntegerLong {
+  val isMasterOnly = true
+  val encodedRequest: ByteString = encode("XDEL", Seq(keyAsString) ++ ids.map(_.serialize))
+}
+
+case class Xlen[K](key: K)(implicit redisKey: ByteStringSerializer[K])
+  extends SimpleClusterKey[K] with RedisCommandIntegerLong {
+  val isMasterOnly = false
+  val encodedRequest: ByteString = encode("XLEN", Seq(keyAsString))
+}
+
+case class Xrange[K, F, V](key: K, start: RequestStreamId, end: RequestStreamId, count: Option[Long] = None)(implicit serializerK: ByteStringSerializer[K], deserializerF: ByteStringDeserializer[F], deserializerV: ByteStringDeserializer[V])
+  extends SimpleClusterKey[K] with RedisCommandMultiBulk[Seq[StreamEntry[F, V]]] {
+  val isMasterOnly = false
+  val encodedRequest: ByteString = encode("XRANGE", Xrange.buildArgs(key, start, end, count))
+  def decodeReply(reply: MultiBulk): Seq[StreamEntry[F, V]] = StreamEntryDecoder.toSeqEntry(reply)
+}
+
+private [redis] object Xrange {
+  def buildArgs[K](key: K, id1: RequestStreamId, id2: RequestStreamId, count: Option[Long])(implicit serializerK: ByteStringSerializer[K]): Seq[ByteString] = {
+    val builder = Seq.newBuilder[ByteString]
+    builder += serializerK.serialize(key)
+    builder += id1.serialize
+    builder += id2.serialize
+    if (count.isDefined) {
+      builder += ByteString("COUNT")
+      builder += ByteString(count.get.toString)
+    }
+    builder.result()
+  }
+}
+
+case class Xrevrange[K, F, V](key: K, end: RequestStreamId, start: RequestStreamId, count: Option[Long] = None)(implicit serializerK: ByteStringSerializer[K], deserializerF: ByteStringDeserializer[F], deserializerV: ByteStringDeserializer[V])
+  extends SimpleClusterKey[K] with RedisCommandMultiBulk[Seq[StreamEntry[F, V]]] {
+  val isMasterOnly = false
+  val encodedRequest: ByteString = encode("XREVRANGE", Xrange.buildArgs(key, end, start, count))
+  def decodeReply(reply: MultiBulk): Seq[StreamEntry[F, V]] = StreamEntryDecoder.toSeqEntry(reply)
+}
+
+case class Xtrim[K](key: K, trimStrategy: TrimStrategy)(implicit serializerK: ByteStringSerializer[K])
+  extends SimpleClusterKey[K] with RedisCommandIntegerLong {
+  val isMasterOnly = true
+  val encodedRequest: ByteString = encode("XTRIM", Seq(keyAsString) ++ trimStrategy.toByteString)
+}
+
+case class Xread[K, F, V](streams: Seq[(K, RequestStreamId)], count: Option[Long])(implicit serializerK: ByteStringSerializer[K], deserializerK: ByteStringDeserializer[K], deserializerF: ByteStringDeserializer[F], deserializerV: ByteStringDeserializer[V])
+  extends RedisCommandMultiBulk[Option[Seq[(K, Seq[StreamEntry[F, V]])]]] {
+  val keys = streams.map(_._1)
+  val isMasterOnly = false
+  val encodedRequest: ByteString = {
+    val builder = Seq.newBuilder[ByteString]
+
+    if (count.isDefined) {
+      builder += ByteString("COUNT")
+      builder += ByteString(count.get.toString)
+    }
+
+    builder += ByteString("STREAMS")
+    builder ++= streams.map(p => serializerK.serialize(p._1))
+    builder ++= streams.map(p => p._2.serialize)
+
+    encode("XREAD", builder.result())
+  }
+
+  def decodeReply(r: MultiBulk): Option[Seq[(K, Seq[StreamEntry[F, V]])]] =
+    StreamEntryDecoder.toOptionSeqStringSeqEntry(r)(deserializerK, deserializerF, deserializerV)
+}
+
+private [redis] object StreamEntryDecoder {
+  def toEntry[F, V](mb: MultiBulk)(implicit deserializerF: ByteStringDeserializer[F], deserializerV: ByteStringDeserializer[V]): StreamEntry[F, V] = {
+    val r = mb.responses.get
+    val id = StreamId.deserialize(r(0).toByteString)
+    val fields = r(1).asInstanceOf[MultiBulk].responses.get.map(_.toByteString).grouped(2).map(p => (deserializerF.deserialize(p(0)), deserializerV.deserialize(p(1)))).toSeq
+    StreamEntry(id, fields)
+  }
+
+  def toSeqEntry[F, V](mb: MultiBulk)(implicit deserializerF: ByteStringDeserializer[F], deserializerV: ByteStringDeserializer[V]): Seq[StreamEntry[F, V]] = {
+    mb.responses.map(r => r.map(_.asInstanceOf[MultiBulk]).map(toEntry[F,V])).getOrElse(Seq())
+  }
+
+  def toOptionSeqStringSeqEntry[K, F, V](mb: MultiBulk)(implicit deserializerK: ByteStringDeserializer[K], deserializerF: ByteStringDeserializer[F], deserializerV: ByteStringDeserializer[V]): Option[Seq[(K, Seq[StreamEntry[F, V]])]] =
+    mb.responses.map { r =>
+      r.map(_.asInstanceOf[MultiBulk]).map(toStringSeqEntry[K,F,V])
+    }
+
+  def toStringSeqEntry[K, F, V](mb: MultiBulk)(implicit deserializerK: ByteStringDeserializer[K], deserializerF: ByteStringDeserializer[F], deserializerV: ByteStringDeserializer[V]): (K, Seq[StreamEntry[F, V]]) = {
+    val r = mb.responses.get
+    val key = deserializerK.deserialize(r(0).toByteString)
+    val entries = toSeqEntry[F,V](r(1).asInstanceOf[MultiBulk])
+    (key, entries)
+  }
+}

--- a/src/main/scala/redis/commands/BSortedSets.scala
+++ b/src/main/scala/redis/commands/BSortedSets.scala
@@ -1,0 +1,18 @@
+package redis.commands
+
+
+import redis.{ByteStringDeserializer, Request}
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import redis.api.bsortedsets._
+
+/**
+  * Blocking commands on Sorted Sets
+  */
+trait BSortedSets extends Request {
+  def bzpopmax[R: ByteStringDeserializer](keys: Seq[String], timeout: FiniteDuration = Duration.Zero): Future[Option[(String, R, Double)]] =
+    send(Bzpopmax(keys, timeout))
+
+  def bzpopmin[R: ByteStringDeserializer](keys: Seq[String], timeout: FiniteDuration = Duration.Zero): Future[Option[(String, R, Double)]] =
+    send(Bzpopmin(keys, timeout))
+}

--- a/src/main/scala/redis/commands/Connection.scala
+++ b/src/main/scala/redis/commands/Connection.scala
@@ -21,5 +21,8 @@ trait Connection extends Request {
 
   def select(index: Int): Future[Boolean] =
     send(Select(index))
+
+  def swapdb(index1: Int, index2: Int): Future[Boolean] =
+    send(Swapdb(index1, index2))
 }
 

--- a/src/main/scala/redis/commands/Keys.scala
+++ b/src/main/scala/redis/commands/Keys.scala
@@ -97,4 +97,6 @@ trait Keys extends Request {
   def scan(cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[Cursor[Seq[String]]] =
     send(Scan(cursor, count, matchGlob))
 
+  def unlink(keys: String*): Future[Long] =
+    send(Unlink(keys))
 }

--- a/src/main/scala/redis/commands/Keys.scala
+++ b/src/main/scala/redis/commands/Keys.scala
@@ -29,8 +29,12 @@ trait Keys extends Request {
   def keys(pattern: String): Future[Seq[String]] =
     send(Keys(pattern))
 
-  def migrate(host: String, port: Int, key: String, destinationDB: Int, timeout: FiniteDuration): Future[Boolean] = {
-    send(Migrate(host, port, key, destinationDB, timeout))
+  def migrate(host: String, port: Int, key: String, destinationDB: Int, timeout: FiniteDuration, copy: Boolean = false, replace: Boolean = false, password: Option[String] = None): Future[Boolean] = {
+    send(Migrate(host, port, Seq(key), destinationDB, timeout, copy, replace, password))
+  }
+
+  def migrateMany(host: String, port: Int, keys: Seq[String], destinationDB: Int, timeout: FiniteDuration, copy: Boolean = false, replace: Boolean = false, password: Option[String] = None): Future[Boolean] = {
+    send(Migrate(host, port, keys, destinationDB, timeout, copy, replace, password))
   }
 
   def move(key: String, db: Int): Future[Boolean] =

--- a/src/main/scala/redis/commands/Lists.scala
+++ b/src/main/scala/redis/commands/Lists.scala
@@ -28,8 +28,8 @@ trait Lists extends Request {
   def lpush[V: ByteStringSerializer](key: String, values: V*): Future[Long] =
     send(Lpush(key, values))
 
-  def lpushx[V: ByteStringSerializer](key: String, value: V): Future[Long] =
-    send(Lpushx(key, value))
+  def lpushx[V: ByteStringSerializer](key: String, values: V*): Future[Long] =
+    send(Lpushx(key, values))
 
   def lrange[R: ByteStringDeserializer](key: String, start: Long, stop: Long): Future[Seq[R]] =
     send(Lrange(key, start, stop))
@@ -52,7 +52,7 @@ trait Lists extends Request {
   def rpush[V: ByteStringSerializer](key: String, values: V*): Future[Long] =
     send(Rpush(key, values))
 
-  def rpushx[V: ByteStringSerializer](key: String, value: V): Future[Long] =
-    send(Rpushx(key, value))
+  def rpushx[V: ByteStringSerializer](key: String, values: V*): Future[Long] =
+    send(Rpushx(key, values))
 
 }

--- a/src/main/scala/redis/commands/Server.scala
+++ b/src/main/scala/redis/commands/Server.scala
@@ -40,11 +40,11 @@ trait Server extends Request {
   def debugSegfault(): Future[String] =
     send(DebugSegfault)
 
-  def flushall(): Future[Boolean] =
-    send(Flushall)
+  def flushall(async: Boolean = false): Future[Boolean] =
+    send(Flushall(async))
 
-  def flushdb(): Future[Boolean] =
-    send(Flushdb)
+  def flushdb(async: Boolean = false): Future[Boolean] =
+    send(Flushdb(async))
 
   def info(): Future[String] =
     send(Info())

--- a/src/main/scala/redis/commands/SortedSets.scala
+++ b/src/main/scala/redis/commands/SortedSets.scala
@@ -30,6 +30,12 @@ trait SortedSets extends Request {
   def zinterstoreWeighted(destination: String, keys: Map[String, Double], aggregate: Aggregate = SUM): Future[Long] =
     send(ZinterstoreWeighted(destination, keys, aggregate))
 
+  def zpopmax[R: ByteStringDeserializer](key: String, count: Option[Long] = None): Future[Seq[(R, Double)]] =
+    send(Zpopmax(key, count))
+
+  def zpopmin[R: ByteStringDeserializer](key: String, count: Option[Long] = None): Future[Seq[(R, Double)]] =
+    send(Zpopmin(key, count))
+
   def zrange[R: ByteStringDeserializer](key: String, start: Long, stop: Long): Future[Seq[R]] =
     send(Zrange(key, start, stop))
 

--- a/src/main/scala/redis/commands/Streams.scala
+++ b/src/main/scala/redis/commands/Streams.scala
@@ -1,0 +1,36 @@
+package redis.commands
+
+import redis.api._
+import redis.api.streams._
+import redis.{ByteStringDeserializer, ByteStringSerializer, Request}
+
+import scala.concurrent.Future
+
+trait Streams extends Request {
+  def xadd[V: ByteStringSerializer](key: String, id: RequestStreamId, fields: (String, V)*): Future[StreamId] =
+    send(Xadd(key, id, fields, None))
+
+  def xadd[V: ByteStringSerializer](key: String, trimStrategy: TrimStrategy, id: RequestStreamId, fields: (String, V)*): Future[StreamId] =
+    send(Xadd(key, id, fields, Some(trimStrategy)))
+
+  def xdel(key: String, ids: StreamId*): Future[Long] =
+    send(Xdel(key, ids))
+
+  def xlen(key: String): Future[Long] =
+    send(Xlen(key))
+
+  def xrange[V: ByteStringDeserializer](key: String, start: RequestStreamId, end: RequestStreamId, count: Option[Long] = None): Future[Seq[StreamEntry[String, V]]] =
+    send(Xrange(key, start, end, count))
+
+  def xrevrange[V: ByteStringDeserializer](key: String, end: RequestStreamId, start: RequestStreamId, count: Option[Long] = None): Future[Seq[StreamEntry[String, V]]] =
+    send(Xrevrange(key, end, start, count))
+
+  def xread[V: ByteStringDeserializer](streams: (String, RequestStreamId)*): Future[Option[Seq[(String, Seq[StreamEntry[String, V]])]]] =
+    send(Xread(streams, None))
+
+  def xread[V: ByteStringDeserializer](count: Long, streams: (String, RequestStreamId)*): Future[Option[Seq[(String, Seq[StreamEntry[String, V]])]]] =
+    send(Xread(streams, count = Some(count)))
+
+  def xtrim(key: String, trimStrategy: TrimStrategy): Future[Long] =
+    send(Xtrim(key, trimStrategy))
+}

--- a/src/test/scala/redis/RedisSpec.scala
+++ b/src/test/scala/redis/RedisSpec.scala
@@ -227,8 +227,8 @@ abstract class RedisClusterClients() extends RedisHelper {
     Thread.sleep(2000)
     val nodes = nodePorts.map(s => redisHost + ":" + s).mkString(" ")
 
-    println(s"$redisServerPath/redis-trib.rb create --replicas 1 ${nodes}")
-    val redisTrib = Process(s"$redisServerPath/redis-trib.rb create --replicas 1 ${nodes}").run(
+    println(s"$redisServerPath/redis-cli --cluster create ${nodes} --cluster-replicas 1")
+    val redisTrib = Process(s"$redisServerPath/redis-cli --cluster create ${nodes} --cluster-replicas 1").run(
 
       new ProcessIO(
         (writeInput: OutputStream) => {

--- a/src/test/scala/redis/commands/BSortedSetsSpec.scala
+++ b/src/test/scala/redis/commands/BSortedSetsSpec.scala
@@ -1,0 +1,97 @@
+package redis.commands
+
+import redis._
+import scala.concurrent.Await
+import akka.util.ByteString
+import scala.concurrent.duration._
+
+class BSortedSetsSpec extends RedisStandaloneServer {
+
+  "Blocking Sorted Sets commands" should {
+    "BZPOPMAX" in {
+      "already containing elements" in {
+        val redisB = RedisBlockingClient(port=port)
+        val r = for {
+          _ <- redis.del("bzpopmax1", "bzpopmax2")
+          p <- redis.zadd("bzpopmax1", (0, "a"), (1, "b"))
+          b <- redisB.bzpopmax(Seq("bzpopmax1", "bzpopmax2"))
+        } yield {
+          b mustEqual Some(("bzpopmax1", ByteString("b"), 1))
+        }
+        val rr = Await.result(r, timeOut)
+        redisB.stop()
+        rr
+      }
+
+      "blocking" in {
+        val redisB = RedisBlockingClient(port=port)
+        val rr = within(1.seconds, 10.seconds) {
+          val r = redis.del("bzpopmaxBlock").flatMap(_ => {
+            val bzpopmax = redisB.bzpopmax(Seq("bzpopmaxBlock"))
+            Thread.sleep(1000)
+            redis.zadd("bzpopmaxBlock", (0, "a"), (1, "b"))
+            bzpopmax
+          })
+          Await.result(r, timeOut) mustEqual Some(("bzpopmaxBlock", ByteString("b"), 1))
+        }
+        redisB.stop()
+        rr
+      }
+
+      "blocking timeout" in {
+        val redisB = RedisBlockingClient(port=port)
+        val rr = within(1.seconds, 10.seconds) {
+          val r = redis.del("bzpopmaxBlockTimeout").flatMap(_ => {
+            redisB.bzpopmax(Seq("bzpopmaxBlockTimeout"), 1.seconds)
+          })
+          Await.result(r, timeOut) must beNone
+        }
+        redisB.stop()
+        rr
+      }
+    }
+    
+    "BZPOPMIN" in {
+      "already containing elements" in {
+        val redisB = RedisBlockingClient(port=port)
+        val r = for {
+          _ <- redis.del("bzpopmin1", "bzpopmin2")
+          p <- redis.zadd("bzpopmin1", (0, "a"), (1, "b"))
+          b <- redisB.bzpopmin(Seq("bzpopmin1", "bzpopmin2"))
+        } yield {
+          b mustEqual Some(("bzpopmin1", ByteString("a"), 0))
+        }
+        val rr = Await.result(r, timeOut)
+        redisB.stop()
+        rr
+      }
+
+      "blocking" in {
+        val redisB = RedisBlockingClient(port=port)
+        val rr = within(1.seconds, 10.seconds) {
+          val r = redis.del("bzpopminBlock").flatMap(_ => {
+            val bzpopmin = redisB.bzpopmin(Seq("bzpopminBlock"))
+            Thread.sleep(1000)
+            redis.zadd("bzpopminBlock", (0, "a"), (1, "b"))
+            bzpopmin
+          })
+          Await.result(r, timeOut) mustEqual Some(("bzpopminBlock", ByteString("a"), 0))
+        }
+        redisB.stop()
+        rr
+      }
+
+      "blocking timeout" in {
+        val redisB = RedisBlockingClient(port=port)
+        val rr = within(1.seconds, 10.seconds) {
+          val r = redis.del("bzpopminBlockTimeout").flatMap(_ => {
+            redisB.bzpopmin(Seq("bzpopminBlockTimeout"), 1.seconds)
+          })
+          Await.result(r, timeOut) must beNone
+        }
+        redisB.stop()
+        rr
+      }
+    }
+  }
+}

--- a/src/test/scala/redis/commands/ConnectionSpec.scala
+++ b/src/test/scala/redis/commands/ConnectionSpec.scala
@@ -31,8 +31,8 @@ class ConnectionSpec extends RedisStandaloneServer {
     "SELECT" in {
       Await.result(redis.select(1), timeOut) mustEqual true
       Await.result(redis.select(0), timeOut) mustEqual true
-      Await.result(redis.select(-1), timeOut) must throwA[ReplyErrorException]("ERR invalid DB index")
-      Await.result(redis.select(1000), timeOut) must throwA[ReplyErrorException]("ERR invalid DB index")
+      Await.result(redis.select(-1), timeOut) must throwA[ReplyErrorException]("ERR DB index is out of range")
+      Await.result(redis.select(1000), timeOut) must throwA[ReplyErrorException]("ERR DB index is out of range")
     }
   }
 }

--- a/src/test/scala/redis/commands/ConnectionSpec.scala
+++ b/src/test/scala/redis/commands/ConnectionSpec.scala
@@ -34,5 +34,15 @@ class ConnectionSpec extends RedisStandaloneServer {
       Await.result(redis.select(-1), timeOut) must throwA[ReplyErrorException]("ERR DB index is out of range")
       Await.result(redis.select(1000), timeOut) must throwA[ReplyErrorException]("ERR DB index is out of range")
     }
+    "SWAPDB" in {
+      Await.result(redis.select(0), timeOut) mustEqual true
+      Await.result(redis.set("key1", "value1"), timeOut) mustEqual true
+      Await.result(redis.select(1), timeOut) mustEqual true
+      Await.result(redis.set("key2", "value2"), timeOut) mustEqual true
+      Await.result(redis.swapdb(0, 1), timeOut) mustEqual true
+      Await.result(redis.get("key1"), timeOut) mustEqual Some(ByteString("value1"))
+      Await.result(redis.select(0), timeOut) mustEqual true
+      Await.result(redis.get("key2"), timeOut) mustEqual Some(ByteString("value2"))
+    }
   }
 }

--- a/src/test/scala/redis/commands/KeysSpec.scala
+++ b/src/test/scala/redis/commands/KeysSpec.scala
@@ -24,7 +24,7 @@ class KeysSpec extends RedisStandaloneServer {
         d <- redis.dump("dumpKey")
       } yield {
         s mustEqual true
-        d mustEqual Some(ByteString(0, 5, 118, 97, 108, 117, 101, 8, 0, 56, -37, 45, -121, 104, -77, 17, 86))
+        d mustEqual Some(ByteString(0, 5, 118, 97, 108, 117, 101, 9, 0, 81, 4, -112, -12, -107, 44, -8, -33))
       }
       Await.result(r, timeOut)
     }
@@ -349,7 +349,7 @@ class KeysSpec extends RedisStandaloneServer {
         restore <- redis.restore("restoreKey", serializedValue = dump.get)
       } yield {
         s mustEqual true
-        dump mustEqual Some(ByteString(0, 5, 118, 97, 108, 117, 101, 8, 0, 56, -37, 45, -121, 104, -77, 17, 86))
+        dump mustEqual Some(ByteString(0, 5, 118, 97, 108, 117, 101, 9, 0, 81, 4, -112, -12, -107, 44, -8, -33))
         restore mustEqual true
       }
       Await.result(r, timeOut)

--- a/src/test/scala/redis/commands/KeysSpec.scala
+++ b/src/test/scala/redis/commands/KeysSpec.scala
@@ -379,5 +379,15 @@ class KeysSpec extends RedisStandaloneServer {
       Await.result(r, timeOut)
     }
 
+    "UNLINK" in {
+      val r = for {
+        s <- redis.set("unlinkKey", "value")
+        d <- redis.unlink("unlinkKey", "unlinkKeyNonexisting")
+      } yield {
+        s mustEqual true
+        d mustEqual 1
+      }
+      Await.result(r, timeOut)
+    }
   }
 }

--- a/src/test/scala/redis/commands/KeysSpec.scala
+++ b/src/test/scala/redis/commands/KeysSpec.scala
@@ -24,7 +24,7 @@ class KeysSpec extends RedisStandaloneServer {
         d <- redis.dump("dumpKey")
       } yield {
         s mustEqual true
-        d mustEqual Some(ByteString(0, 5, 118, 97, 108, 117, 101, 7, 0, 126, -60, 20, -53, -55, 96, 78, 116))
+        d mustEqual Some(ByteString(0, 5, 118, 97, 108, 117, 101, 8, 0, 56, -37, 45, -121, 104, -77, 17, 86))
       }
       Await.result(r, timeOut)
     }
@@ -286,7 +286,7 @@ class KeysSpec extends RedisStandaloneServer {
         restore <- redis.restore("restoreKey", serializedValue = dump.get)
       } yield {
         s mustEqual true
-        dump mustEqual Some(ByteString(0, 5, 118, 97, 108, 117, 101, 7, 0, 126, -60, 20, -53, -55, 96, 78, 116))
+        dump mustEqual Some(ByteString(0, 5, 118, 97, 108, 117, 101, 8, 0, 56, -37, 45, -121, 104, -77, 17, 86))
         restore mustEqual true
       }
       Await.result(r, timeOut)

--- a/src/test/scala/redis/commands/ListsSpec.scala
+++ b/src/test/scala/redis/commands/ListsSpec.scala
@@ -77,16 +77,16 @@ class ListsSpec extends RedisStandaloneServer {
       val r = for {
         _ <- redis.del("lpushxKey")
         _ <- redis.del("lpushxKeyOther")
-        i <- redis.rpush("lpushxKey", "world")
-        ii <- redis.lpushx("lpushxKey", "hello")
-        zero <- redis.lpushx("lpushxKeyOther", "hello")
+        i <- redis.rpush("lpushxKey", "c")
+        ii <- redis.lpushx("lpushxKey", "b", "a")
+        zero <- redis.lpushx("lpushxKeyOther", "b", "a")
         list <- redis.lrange("lpushxKey", 0, -1)
         listOther <- redis.lrange("lpushxKeyOther", 0, -1)
       } yield {
         i mustEqual 1
-        ii mustEqual 2
+        ii mustEqual 3
         zero mustEqual 0
-        list mustEqual Seq(ByteString("hello"), ByteString("world"))
+        list mustEqual Seq(ByteString("a"), ByteString("b"), ByteString("c"))
         listOther must beEmpty
       }
       Await.result(r, timeOut)
@@ -197,16 +197,16 @@ class ListsSpec extends RedisStandaloneServer {
       val r = for {
         _ <- redis.del("rpushxKey")
         _ <- redis.del("rpushxKeyOther")
-        i <- redis.rpush("rpushxKey", "hello")
-        ii <- redis.rpushx("rpushxKey", "world")
-        zero <- redis.rpushx("rpushxKeyOther", "world")
+        i <- redis.rpush("rpushxKey", "a")
+        ii <- redis.rpushx("rpushxKey", "b", "c")
+        zero <- redis.rpushx("rpushxKeyOther", "a", "b")
         list <- redis.lrange("rpushxKey", 0, -1)
         listOther <- redis.lrange("rpushxKeyOther", 0, -1)
       } yield {
         i mustEqual 1
-        ii mustEqual 2
+        ii mustEqual 3
         zero mustEqual 0
-        list mustEqual Seq(ByteString("hello"), ByteString("world"))
+        list mustEqual Seq(ByteString("a"), ByteString("b"), ByteString("c"))
         listOther must beEmpty
       }
       Await.result(r, timeOut)

--- a/src/test/scala/redis/commands/ServerSpec.scala
+++ b/src/test/scala/redis/commands/ServerSpec.scala
@@ -70,8 +70,16 @@ class ServerSpec extends RedisStandaloneServer {
       Await.result(redis.flushall(), timeOut) must beTrue
     }
 
+    "FLUSHALL ASYNC" in {
+      Await.result(redis.flushall(async = true), timeOut) must beTrue
+    }
+
     "FLUSHDB" in {
       Await.result(redis.flushdb(), timeOut) must beTrue
+    }
+
+    "FLUSHDB ASYNC" in {
+      Await.result(redis.flushdb(async = true), timeOut) must beTrue
     }
 
     "INFO" in {

--- a/src/test/scala/redis/commands/SortedSetsSpec.scala
+++ b/src/test/scala/redis/commands/SortedSetsSpec.scala
@@ -95,6 +95,34 @@ class SortedSetsSpec extends RedisStandaloneServer {
       Await.result(r, timeOut)
     }
 
+    "ZPOPMAX" in {
+      val r = for {
+        _ <- redis.del("zpopmaxKey")
+        z1 <- redis.zadd("zpopmaxKey",  1.0 -> "one", (2, "two"), (3, "three"))
+        zp1 <- redis.zpopmax("zpopmaxKey")
+        zp2 <- redis.zpopmax("zpopmaxKey", Some(2))
+      } yield {
+        z1 mustEqual 3
+        zp1 mustEqual Seq((ByteString("three"), 3))
+        zp2 mustEqual Seq((ByteString("two"), 2), (ByteString("one"), 1))
+      }
+      Await.result(r, timeOut)
+    }
+
+    "ZPOPMIN" in {
+      val r = for {
+        _ <- redis.del("zpopminKey")
+        z1 <- redis.zadd("zpopminKey",  1.0 -> "one", (2, "two"), (3, "three"))
+        zp1 <- redis.zpopmin("zpopminKey")
+        zp2 <- redis.zpopmin("zpopminKey", Some(2))
+      } yield {
+        z1 mustEqual 3
+        zp1 mustEqual Seq((ByteString("one"), 1))
+        zp2 mustEqual Seq((ByteString("two"), 2), (ByteString("three"), 3))
+      }
+      Await.result(r, timeOut)
+    }
+
     "ZRANGE" in {
       val r = for {
         _ <- redis.del("zrangeKey")

--- a/src/test/scala/redis/commands/StreamsSpec.scala
+++ b/src/test/scala/redis/commands/StreamsSpec.scala
@@ -1,0 +1,190 @@
+package redis.commands
+
+import redis._
+import redis.api._
+import scala.concurrent.{Await, Future}
+import akka.util.ByteString
+
+class StreamsSpec extends RedisStandaloneServer {
+  "Streams commands" should {
+    "XADD" in {
+      val key = "xaddKey"
+      val r = for {
+        _ <- redis.del(key)
+        a <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", 1))
+      } yield {
+        a.time mustNotEqual 0
+      }
+      Await.result(r, timeOut)
+    }
+
+    "XADD MAXLEN" in {
+      val key = "xaddmaxlenKey"
+      val r = for {
+        _ <- redis.del(key)
+        _ <- redis.xadd(key, MaxLength(1), StreamId.AUTOGENERATE, ("item", 1))
+        _ <- redis.xadd(key, MaxLength(1), StreamId.AUTOGENERATE, ("item", 2))
+        l <- redis.xlen(key)
+      } yield {
+        l mustEqual 1
+      }
+      Await.result(r, timeOut)
+    }
+
+    "XDEL" in {
+      val key = "xdelKey"
+      val r = for {
+        _ <- redis.del(key)
+        a <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", 1))
+        d <- redis.xdel(key, a)
+      } yield {
+        d mustEqual 1
+      }
+      Await.result(r, timeOut)
+    }
+
+    "XLEN" in {
+      val key = "xlenKey"
+      val r = for {
+        _ <- redis.del(key)
+        _ <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", 1))
+        _ <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", 2))
+        _ <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", 3))
+        l <- redis.xlen(key)
+      } yield {
+        l mustEqual 3
+      }
+      Await.result(r, timeOut)
+    }
+
+    "XRANGE" in {
+      val key = "xrangeKey"
+      val r = for {
+        _ <- redis.del(key)
+        r1 <- redis.xrange(key, StreamId.MIN, StreamId.MAX)
+        a1 <- redis.xadd(key, StreamId.AUTOGENERATE, ("b", "1"), ("a", "one"))
+        a2 <- redis.xadd(key, StreamId.AUTOGENERATE, ("a", "2"), ("b", "two"))
+        r2 <- redis.xrange[ByteString](key, StreamId.MIN, StreamId.MAX)
+      } yield {
+        r1.length mustEqual 0
+        r2.length mustEqual 2
+        r2(0).id mustEqual a1
+        r2(0).fields mustEqual Seq("b" -> ByteString("1"), "a" -> ByteString("one"))
+        r2(1).id mustEqual a2
+        r2(1).fields mustEqual Seq("a" -> ByteString("2"), "b" -> ByteString("two"))
+      }
+      Await.result(r, timeOut)
+    }
+
+    "XRANGE COUNT" in {
+      val key = "xrangecountKey"
+      val r = for {
+        _ <- redis.del(key)
+        a1 <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", "1"))
+        _ <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", "2"))
+        r1 <- redis.xrange(key, StreamId.MIN, StreamId.MAX, Some(1))
+      } yield {
+        r1.length mustEqual 1
+        r1(0).id mustEqual a1
+        r1(0).fields mustEqual Seq("item" -> ByteString("1"))
+      }
+      Await.result(r, timeOut)
+    }
+
+    "XREAD" in {
+      val key1 = "xreadKey1"
+      val key2 = "xreadKey2"
+      val r = for {
+        _ <- redis.del(key1, key2)
+        a1 <- redis.xadd(key1, StreamId.AUTOGENERATE, ("item", "1"))
+        a2 <- redis.xadd(key1, StreamId.AUTOGENERATE, ("item", "2"))
+        a3 <- redis.xadd(key2, StreamId.AUTOGENERATE, ("item", "3"))
+        r1 <- redis.xread(key1 -> StreamId(0), key2 -> StreamId(0))
+        _ <- redis.del(key1, key2)
+        r2 <- redis.xread(key1 -> StreamId(0), key2 -> StreamId(0))
+      } yield {
+        val x = r1.get
+        x.length mustEqual 2
+        x(0)._1 mustEqual key1
+        x(0)._2.length mustEqual 2
+        x(0)._2(0).id mustEqual a1
+        x(0)._2(0).fields mustEqual Seq(("item" -> ByteString("1")))
+        x(0)._2(1).fields mustEqual Seq(("item" -> ByteString("2")))
+        x(1)._1 mustEqual key2
+        x(1)._2.length mustEqual 1
+        x(1)._2(0).id mustEqual a3
+        x(1)._2(0).fields mustEqual Seq(("item" -> ByteString("3")))
+        r2 mustEqual None
+      }
+      Await.result(r, timeOut)
+    }
+
+    "XREAD COUNT" in {
+      val key = "xreadcountKey"
+      val r = for {
+        _ <- redis.del(key)
+        a1 <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", "1"))
+        a2 <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", "2"))
+        _ <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", "3"))
+        r1 <- redis.xread(1, key -> a1)
+      } yield {
+        val x = r1.get
+        x.length mustEqual 1
+        x(0)._1 mustEqual key
+        x(0)._2.length mustEqual 1
+        x(0)._2(0).id mustEqual a2
+        x(0)._2(0).fields mustEqual Seq(("item" -> ByteString("2")))
+      }
+      Await.result(r, timeOut)
+    }
+
+
+    "XREVRANGE" in {
+      val key = "xrevrangeKey"
+      val r = for {
+        _ <- redis.del(key)
+        a1 <- redis.xadd(key, StreamId.AUTOGENERATE, ("b", "1"), ("a", "one"))
+        a2 <- redis.xadd(key, StreamId.AUTOGENERATE, ("a", "2"), ("b", "two"))
+        r1 <- redis.xrevrange[ByteString](key, StreamId.MAX, StreamId.MIN)
+      } yield {
+        r1.length mustEqual 2
+        r1(0).id mustEqual a2
+        r1(0).fields mustEqual Seq("a" -> ByteString("2"), "b" -> ByteString("two"))
+        r1(1).id mustEqual a1
+        r1(1).fields mustEqual Seq("b" -> ByteString("1"), "a" -> ByteString("one"))
+      }
+      Await.result(r, timeOut)
+    }
+
+    "XREVRANGE COUNT" in {
+      val key = "xrevrangecountKey"
+      val r = for {
+        _ <- redis.del(key)
+        _ <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", "1"))
+        a2 <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", "2"))
+        r1 <- redis.xrevrange(key, StreamId.MAX, StreamId.MIN, Some(1))
+      } yield {
+        r1.length mustEqual 1
+        r1(0).id mustEqual a2
+        r1(0).fields mustEqual Seq("item" -> ByteString("2"))
+      }
+      Await.result(r, timeOut)
+    }
+
+    "XTRIM" in {
+      val key = "xtrimKey"
+      val r = for {
+        _ <- redis.del(key)
+        _ <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", "1"))
+        _ <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", "2"))
+        _ <- redis.xadd(key, StreamId.AUTOGENERATE, ("item", "3"))
+        r <- redis.xtrim(key, MaxLength(1))
+        l <- redis.xlen(key)
+      } yield {
+        r mustEqual 2
+        l mustEqual 1
+      }
+      Await.result(r, timeOut)
+    }
+  }
+}


### PR DESCRIPTION
Hi there!

As noted in my previous pull request, I've made some changes to support redis 5.0 and the new Streams commands. This branch is based on my features/redis-4.0 branch, so please disregard the common changes. (I'll rebase this if the other pull request is accepted.)

This is still a work-in-progress, but I think there is enough here to get meaningful feedback, especially on the interface and reply decoding for stream commands.  If the current approach looks good, I'll add support for consumer groups and blocking stream commands.

Thanks,
-David