### PR TITLE
Add ZPOPMIN & ZPOPMAX support

### DIFF
--- a/src/main/scala/redis/api/SortedSets.scala
+++ b/src/main/scala/redis/api/SortedSets.scala
@@ -234,3 +234,9 @@ case class Zscan[K, C, R](key: K, cursor: C, count: Option[Int], matchGlob: Opti
      score -> deserializerR.deserialize(data.toByteString)
    }.toSeq
 }
+
+case class Zpopmin[K, R](key: K, count: Long)(implicit keySeria: ByteStringSerializer[K], countSeria: ByteStringSerializer[Long], deserializerR: ByteStringDeserializer[R]) extends SimpleClusterKey[K] with RedisCommandMultiBulkSeqByteString[R] {
+  val isMasterOnly = false
+  val encodedRequest: ByteString = encode("ZPOPMIN", Seq(keyAsString, countSeria.serialize(count)))
+  val deserializer: ByteStringDeserializer[R] = deserializerR
+}

--- a/src/main/scala/redis/api/SortedSets.scala
+++ b/src/main/scala/redis/api/SortedSets.scala
@@ -240,3 +240,8 @@ case class Zpopmin[K, R](key: K, count: Long)(implicit keySeria: ByteStringSeria
   val encodedRequest: ByteString = encode("ZPOPMIN", Seq(keyAsString, countSeria.serialize(count)))
   val deserializer: ByteStringDeserializer[R] = deserializerR
 }
+case class Zpopmax[K, R](key: K, count: Long)(implicit keySeria: ByteStringSerializer[K], countSeria: ByteStringSerializer[Long], deserializerR: ByteStringDeserializer[R]) extends SimpleClusterKey[K] with RedisCommandMultiBulkSeqByteString[R] {
+  val isMasterOnly = false
+  val encodedRequest: ByteString = encode("ZPOPMAX", Seq(keyAsString, countSeria.serialize(count)))
+  val deserializer: ByteStringDeserializer[R] = deserializerR
+}

--- a/src/main/scala/redis/commands/SortedSets.scala
+++ b/src/main/scala/redis/commands/SortedSets.scala
@@ -92,5 +92,7 @@ trait SortedSets extends Request {
   def zscan[R: ByteStringDeserializer](key: String, cursor: Int = 0, count: Option[Int] = None, matchGlob: Option[String] = None): Future[Cursor[Seq[(Double, R)]]] =
     send(Zscan(key, cursor, count, matchGlob))
 
+  def zpopmin[R: ByteStringDeserializer](key: String, count: Long = 1): Future[Seq[R]] = 
+    send(Zpopmin(key, count))
 }
 

--- a/src/main/scala/redis/commands/SortedSets.scala
+++ b/src/main/scala/redis/commands/SortedSets.scala
@@ -94,5 +94,8 @@ trait SortedSets extends Request {
 
   def zpopmin[R: ByteStringDeserializer](key: String, count: Long = 1): Future[Seq[R]] = 
     send(Zpopmin(key, count))
+
+  def zpopmax[R: ByteStringDeserializer](key: String, count: Long = 1): Future[Seq[R]] = 
+    send(Zpopmax(key, count))
 }
 

--- a/src/test/scala/redis/commands/SortedSetsSpec.scala
+++ b/src/test/scala/redis/commands/SortedSetsSpec.scala
@@ -352,5 +352,22 @@ class SortedSetsSpec extends RedisStandaloneServer {
       }
       Await.result(r, timeOut)
     }
+
+    "ZPOPMAX" in {
+      val r = for {
+        _ <- redis.del("zpopmaxKey")
+        z1 <- redis.zadd("zpopmaxKey", (1, "one"))
+        z1r <-redis.zpopmax("zpopmaxKey")
+        _ <- redis.del("zpopmaxKey")
+        z2 <- redis.zadd("zpopmaxKey", (3, "three"), (2, "two"), (1, "one")) 
+        z2r <- redis.zpopmax("zpopmaxKey", 2)
+      } yield {
+        z1 mustEqual 1
+        z1r mustEqual Seq(ByteString("one"), ByteString("1"))
+        z2 mustEqual 3
+        z2r mustEqual Seq(ByteString("three"), ByteString("3"), ByteString("two"), ByteString("2"))
+      }
+      Await.result(r, timeOut)
+    }
   }
 }

--- a/src/test/scala/redis/commands/SortedSetsSpec.scala
+++ b/src/test/scala/redis/commands/SortedSetsSpec.scala
@@ -336,5 +336,21 @@ class SortedSetsSpec extends RedisStandaloneServer {
       }
       Await.result(r, timeOut)
     }
+
+    "ZPOPMIN" in {
+      val r = for {
+        _ <- redis.del("zpopminKey")
+        z1 <- redis.zadd("zpopminKey", (1, "one"))
+        z1r <-redis.zpopmin("zpopminKey")
+        z2 <- redis.zadd("zpopminKey", (3, "three"), (2, "two"), (1, "one"))
+        z2r <- redis.zpopmin("zpopminKey", 2)
+      } yield {
+        z1 mustEqual 1
+        z1r mustEqual Seq(ByteString("one"), ByteString("1"))
+        z2 mustEqual 2
+        z2r mustEqual Seq(ByteString("one"), ByteString("1"), ByteString("two"), ByteString("2"))
+      }
+      Await.result(r, timeOut)
+    }
   }
 }


### PR DESCRIPTION
Adds support for the sorted set commands [ZPOPMIN](https://redis.io/commands/zpopmin) and [ZPOPMAX](https://redis.io/commands/zpopmax)