### PR TITLE
[issue-225] Source and target java8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val standardSettings = Def.settings(
   publishTo := sonatypePublishTo.value,
   publishMavenStyle := true,
   git.gitRemoteRepo := "git@github.com:etaty/rediscala.git",
-
+  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   scalacOptions ++= Seq(
     "-encoding", "UTF-8",
     "-Xlint",


### PR DESCRIPTION
Using java13 before the PR:
```sh
java -version # `openjdk version "13.0.2" 2020-01-14 `
sbt package
cd target/scala-2.11
unzip rediscala_2.11-1.9.0.jar
javap -verbose redis/util/CRC16.class | grep version # major version: 57
```

After the PR:

```sh
java -version # `openjdk version "13.0.2" 2020-01-14 `
sbt package
cd target/scala-2.11
unzip rediscala_2.11-1.9.0.jar
javap -verbose redis/util/CRC16.class | grep version # major version: 52
```

It has also been tested in production with our Java 8 backend.

Thanks for the project, we really appreciate it!

Should fix #225 